### PR TITLE
run `yarn-deduplicate` on pre-commit hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: install dependencies
         run: yarn install
 
-      - name: check for duplicate dependencies (if it fails here, then run `yarn yarn-deduplicate` then a `yarn install` then commit)
+      - name: check for duplicate dependencies (if it fails here, then pre-commit hook is not working)
         run: yarn yarn-deduplicate --fail
 
       - name: generate TS definitions for GraphQL schema

--- a/client/package.json
+++ b/client/package.json
@@ -7,13 +7,12 @@
     "build-main-client": "webpack",
     "build-service-worker": "webpack --config webpack.service-worker.config.js",
     "analyze-main-client-bundle": "webpack --config webpack-bundle-analyzer.config.js",
-    "analyze-main-client-bundle-if-changed": "((git diff --name-only --cached | grep 'yarn.lock') && yarn analyze-main-client-bundle) || true",
     "watch": "run-p --print-label 'type-check --watch' 'build-main-client -- --watch --mode=development' 'build-service-worker -- --watch --mode=development'",
     "build": "run-p --print-label type-check build-main-client build-service-worker"
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn analyze-main-client-bundle-if-changed"
+      "pre-commit": "((git diff --name-only --cached | grep 'yarn.lock') && yarn analyze-main-client-bundle) || true "
     }
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged && ((git diff --name-only --cached | grep 'yarn.lock') && yarn yarn-deduplicate) || true"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
Following on from https://github.com/guardian/editorial-tools-pinboard/pull/68 - it make sense to attempt to correct yarn duplicates before committing (like we fix prettier problems). This PR does that by running `yarn-deduplicate` on pre-commit hook