### PR TITLE
gzip client bundle

### DIFF
--- a/cdk/stack.ts
+++ b/cdk/stack.ts
@@ -567,6 +567,7 @@ export class PinBoardStack extends Stack {
         deployOptions: {
           stageName: "api",
         },
+        minimumCompressionSize: 0, // gzip responses where the client (i.e. browser) supports it (via 'Accept-Encoding' header)
       }
     );
 


### PR DESCRIPTION
This turns on compression (most likely gzip) at the API Gateway layer (to avoid the need for build time compression using webpack plugins etc, and extra logic in `bootstrapping-lambda`). 

This halves the load time for the main client bundle from around one second, to around half a second 🎉  ⚡ .