### PR TITLE
upgrade 'source' (design systems) to v4 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,14 +21,13 @@
     "@typescript-eslint/ban-ts-comment": "warn",
     "react/prop-types": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
-    "node/no-restricted-import": [
+    "no-restricted-imports": [
       "error",
-      [
-        {
-          "name": "@guardian/src-foundations/typography",
-          "message": "Please use the modified fonts from fontNormaliser.ts"
-        }
-      ]
+      {
+        "name": "@guardian/source-foundations",
+        "importNames": ["textSans", "headline", "titlepiece", "body"],
+        "message": "Please use the modified fonts from fontNormaliser.ts"
+      }
     ]
   },
   "settings": {

--- a/client/colours.ts
+++ b/client/colours.ts
@@ -1,6 +1,6 @@
-import { palette } from "@guardian/src-foundations";
+import { palette } from "@guardian/source-foundations";
 
-export const pinboardPrimary = palette.brandAltBackground.ctaSecondary; // "#F3C100"
+export const pinboardPrimary = palette.brandAlt["200"]; // "#F3C100"
 export const pinboardSecondaryPastel = palette.sport[600]; // "#90DCFF"
 export const pinMetal = palette.neutral[20]; //"#333333"
 export const unread = palette.news[400]; // "#C70000

--- a/client/fontNormaliser.ts
+++ b/client/fontNormaliser.ts
@@ -1,9 +1,10 @@
 import type {
   FontScaleArgs,
   FontScaleFunctionStr,
-} from "@guardian/src-foundations/dist/types/typography/types";
-// eslint-disable-next-line node/no-restricted-import
-import * as typography from "@guardian/src-foundations/typography";
+} from "@guardian/source-foundations/dist/types/typography/types";
+
+// eslint-disable-next-line no-restricted-imports -- suppress our own lint rule as this is the one legit place to import the fonts
+import * as sourceFoundations from "@guardian/source-foundations";
 
 const defaultToPx = (originalFunc: FontScaleFunctionStr) => (
   options?: FontScaleArgs
@@ -20,7 +21,7 @@ const pixelSizedFont = <T extends FontDefinition>(originalFont: T) =>
     {} as T
   );
 
-export const textSans = pixelSizedFont(typography.textSans);
-export const headline = pixelSizedFont(typography.headline);
-export const titlepiece = pixelSizedFont(typography.titlepiece);
-export const body = pixelSizedFont(typography.body);
+export const textSans = pixelSizedFont(sourceFoundations.textSans);
+export const headline = pixelSizedFont(sourceFoundations.headline);
+export const titlepiece = pixelSizedFont(sourceFoundations.titlepiece);
+export const body = pixelSizedFont(sourceFoundations.body);

--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,9 @@
   "dependencies": {
     "@apollo/client": "^3.5.5",
     "@emotion/react": "^11.1.4",
-    "@guardian/src-foundations": "^3.3.0",
+    "@guardian/source-foundations": "^4.1.0",
+    "@guardian/source-react-components": "^4.0.3",
+    "@guardian/source-react-components-development-kitchen": "^0.0.33",
     "@webscopeio/react-textarea-autocomplete": "4.9.1",
     "aws-appsync-auth-link": "^3.0.7",
     "aws-appsync-subscription-link": "^3.0.9",

--- a/client/src/addToPinboardButton.tsx
+++ b/client/src/addToPinboardButton.tsx
@@ -4,7 +4,7 @@ import PinIcon from "../icons/pin-icon.svg";
 import { css } from "@emotion/react";
 import { pinMetal, pinboardPrimary } from "../colours";
 import { PayloadAndType } from "./types/PayloadAndType";
-import { space } from "@guardian/src-foundations";
+import { space } from "@guardian/source-foundations";
 import { textSans } from "../fontNormaliser";
 import root from "react-shadow/emotion";
 

--- a/client/src/createItemInputBox.tsx
+++ b/client/src/createItemInputBox.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { css } from "@emotion/react";
 import ReactTextareaAutocomplete from "@webscopeio/react-textarea-autocomplete";
 import { PayloadAndType } from "./types/PayloadAndType";
-import { space } from "@guardian/src-foundations";
+import { space } from "@guardian/source-foundations";
 import { PayloadDisplay } from "./payloadDisplay";
 import { User } from "../../shared/graphql/graphql";
 import { userToMentionHandle } from "./util";

--- a/client/src/floaty.tsx
+++ b/client/src/floaty.tsx
@@ -6,7 +6,7 @@ import { pinMetal, pinboardPrimary, unread } from "../colours";
 import { Pinboard, PinboardData } from "./pinboard";
 import { SelectPinboard } from "./selectPinboard";
 import PinIcon from "../icons/pin-icon.svg";
-import { space } from "@guardian/src-foundations";
+import { space } from "@guardian/source-foundations";
 import { PayloadAndType } from "./types/PayloadAndType";
 import { gqlGetPinboardByComposerId, gqlOnCreateItem } from "../gql";
 import { textSans } from "../fontNormaliser";

--- a/client/src/headingPanel.tsx
+++ b/client/src/headingPanel.tsx
@@ -1,7 +1,7 @@
 import React, { PropsWithChildren } from "react";
 import { css } from "@emotion/react";
 import { pinboardPrimary } from "../colours";
-import { space } from "@guardian/src-foundations";
+import { space } from "@guardian/source-foundations";
 interface HeadingPanelProps {
   heading: string;
   clearSelectedPinboard: () => void;

--- a/client/src/itemDisplay.tsx
+++ b/client/src/itemDisplay.tsx
@@ -3,7 +3,7 @@ import React, { Fragment } from "react";
 import { css } from "@emotion/react";
 import { PayloadDisplay } from "./payloadDisplay";
 import { PendingItem } from "./types/PendingItem";
-import { palette, space } from "@guardian/src-foundations";
+import { palette, space } from "@guardian/source-foundations";
 import { formattedDateTime, userToMentionHandle } from "./util";
 import { SeenBy } from "./seenBy";
 import { AvatarRoundel } from "./avatarRoundel";

--- a/client/src/payloadDisplay.tsx
+++ b/client/src/payloadDisplay.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { css } from "@emotion/react";
 import { pinMetal } from "../colours";
 import { PayloadAndType } from "./types/PayloadAndType";
-import { space } from "@guardian/src-foundations";
+import { space } from "@guardian/source-foundations";
 import CrossIcon from "../icons/cross-icon.svg";
 
 interface PayloadDisplayProps extends PayloadAndType {

--- a/client/src/scrollableItems.tsx
+++ b/client/src/scrollableItems.tsx
@@ -8,7 +8,7 @@ import React, {
 } from "react";
 import { css } from "@emotion/react";
 import { unread } from "../colours";
-import { space } from "@guardian/src-foundations";
+import { space } from "@guardian/source-foundations";
 import { ItemDisplay } from "./itemDisplay";
 import { PendingItem } from "./types/PendingItem";
 import { useMutation } from "@apollo/client";

--- a/client/src/selectPinboard.tsx
+++ b/client/src/selectPinboard.tsx
@@ -5,7 +5,7 @@ import { PinboardData } from "./pinboard";
 import { PerPinboard, standardFloatyContainerCss } from "./floaty";
 import { PayloadDisplay } from "./payloadDisplay";
 import { pinboardSecondaryPastel, pinMetal } from "../colours";
-import { space } from "@guardian/src-foundations";
+import { space } from "@guardian/source-foundations";
 import { PayloadAndType } from "./types/PayloadAndType";
 import { gqlListPinboards } from "../gql";
 import { WorkflowStub } from "../../shared/graphql/graphql";

--- a/client/src/sendMessageArea.tsx
+++ b/client/src/sendMessageArea.tsx
@@ -1,6 +1,6 @@
 import { ApolloError, useMutation } from "@apollo/client";
 import { css } from "@emotion/react";
-import { space } from "@guardian/src-foundations";
+import { space } from "@guardian/source-foundations";
 import React, { useState } from "react";
 import { Item, User } from "../../shared/graphql/graphql";
 import { gqlCreateItem } from "../gql";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2420,10 +2420,22 @@
     cookie "^0.3.1"
     iniparser "^1.0.5"
 
-"@guardian/src-foundations@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-3.3.0.tgz#729eb05649c68f295ea174a3f1ae2056ffeb6772"
-  integrity sha512-ephhrEZ2aDQYkc4FM5g1OQju5C2oMS/QCRaSUw58SHNsU1br0Sh3q/KUaTsxO/aJrtk2w9oRMqX2EceRsDdz5Q==
+"@guardian/source-foundations@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/source-foundations/-/source-foundations-4.1.0.tgz#dbcc3fa540bedc61d58dd483b4c96d2042b3760d"
+  integrity sha512-jTeJd43AoEZCltg6ZzGvh5KjUaWMnrN9O/HmWrjCZWg4rqyrRTc3lwCyRmYjTEC9KM3AotOUoF1Y93tnG074Vw==
+  dependencies:
+    mini-svg-data-uri "^1.3.3"
+
+"@guardian/source-react-components-development-kitchen@^0.0.33":
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/@guardian/source-react-components-development-kitchen/-/source-react-components-development-kitchen-0.0.33.tgz#d785992f833f6072072848f1d748d6f9b1e82cb7"
+  integrity sha512-/jpVvjzWxbnhf7Of7lVRv67SAa2i2bQGsvTz+JsZIjgllmZKSLfuwn8SoYzJnQIiRhJhPzRY6PZFhMhZOtcPDw==
+
+"@guardian/source-react-components@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@guardian/source-react-components/-/source-react-components-4.0.3.tgz#0c361a18b5b21fe0db9bb6e4fb8f7e4136bb2ea6"
+  integrity sha512-EZhf48NUtp+3j3lCkBa3pWgT0NC6JCze+yStwlpOfyGR981Z7mgPxjyexIY35Xc7pcgpTXNUpSRWrkYMkSylgw==
 
 "@iarna/toml@^2.2.5":
   version "2.2.5"
@@ -8786,6 +8798,11 @@ mimic-response@^1.0.0, mimic-response@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
+
+mini-svg-data-uri@^1.3.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/mini-svg-data-uri/-/mini-svg-data-uri-1.4.3.tgz#43177b2e93766ba338931a3e2a84a3dfd3a222b8"
+  integrity sha512-gSfqpMRC8IxghvMcxzzmMnWpXAChSA+vy4cia33RgerMS8Fex95akUyQZPbxJJmeBGiGmK7n/1OpUX8ksRjIdA==
 
 minimalistic-assert@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Co-Authored-By: @andrew-nowak

Here we upgrade to v4 of 'source' (design systems) - see...

- https://github.com/guardian/source
- https://theguardian.design/2a1e5182b/v/18820/p/300696-
- https://guardian.github.io/source/?path=/story/getting-started--page

Currently we only use the 'foundations' portion (for colours, spacing, typography etc.), the upgrade involved renaming references to its former name `@guardian/src-foundations` to its new name `@guardian/source-foundations`.

We also added `@guardian/source-react-components` & `@guardian/source-react-components-development-kitchen` as dependencies ready for implementing designs.

Lastly we had to fix-up the `fontNormaliser.ts` (introduced in https://github.com/guardian/editorial-tools-pinboard/pull/42) and associated lint rule, due changes in `@guardian/source-foundations` (i.e. flattening sub dirs such as `typography` down into the root of the package).