### PR TITLE
fix bundle-analyzer, now that we use function for webpack config

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
     "watch-type-check": "yarn type-check --watch",
     "build-main-client": "webpack --mode=production",
     "watch-main-client": "webpack serve --mode=development",
-    "analyze-main-client-bundle": "webpack --config webpack-bundle-analyzer.config.js",
+    "analyze-main-client-bundle": "webpack --config webpack-bundle-analyzer.config.js --mode=production",
     "build-service-worker": "webpack --config webpack.service-worker.config.js --mode=production",
     "watch-service-worker": "webpack --config webpack.service-worker.config.js --mode=development --watch",
     "watch": "run-p --print-label watch-type-check watch-main-client watch-service-worker",

--- a/client/webpack-bundle-analyzer.config.js
+++ b/client/webpack-bundle-analyzer.config.js
@@ -2,10 +2,11 @@ const { merge } = require("webpack-merge");
 const mainClient = require("./webpack.config.js");
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
 
-module.exports = merge(mainClient, {
-  plugins: [
-    new BundleAnalyzerPlugin({
-      analyzerMode: "static",
-    }),
-  ],
-});
+module.exports = (env, argv) =>
+  merge(mainClient(env, argv), {
+    plugins: [
+      new BundleAnalyzerPlugin({
+        analyzerMode: "static",
+      }),
+    ],
+  });


### PR DESCRIPTION
Co-Authored-By: @andrew-nowak 

The bundle analyzer (which runs on pre-commit whenever yarn.lock changes - see #71) was returning a blank screen, upon investigation realised that when we change the webpack config to use function (rather than static object) it broke the `merge` mechanism used in `client/webpack-bundle-analyzer.config.js`.
