### PR TITLE
[tactical] only show 25 pinboards in select view (to prevent rendering crash in PROD)

### DIFF
--- a/client/src/panel.tsx
+++ b/client/src/panel.tsx
@@ -51,7 +51,6 @@ export const Panel: React.FC = () => {
         right: ${right + floatySize / 2}px;
         display: ${isExpanded ? "flex" : "none"};
         flex-direction: column;
-        justify-content: space-between;
         font-family: sans-serif;
         border-top-left-radius: 4px;
         border-top-right-radius: 4px;

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -4,3 +4,5 @@ export const userTableTTLAttribute = "ttlEpochSeconds";
 
 export const publicVapidKey =
   "BAJ1E479bw4iqDH3nTg-OhzLw1daQ9Hfn6EY0x40M9AXGgEew4dBpAb_LE35plZ6YhU2VY87LLJtytE7hJKP9GM";
+
+export const MAX_PINBOARDS_TO_DISPLAY = 25;

--- a/workflow-bridge-lambda/src/index.ts
+++ b/workflow-bridge-lambda/src/index.ts
@@ -1,6 +1,7 @@
 import fetch from "node-fetch";
 import { WorkflowStub } from "../../shared/graphql/graphql";
 import { getEnvironmentVariableOrThrow } from "../../shared/environmentVariables";
+import { MAX_PINBOARDS_TO_DISPLAY } from "../../shared/constants";
 
 const WORKFLOW_DATASTORE_API_URL = `http://${getEnvironmentVariableOrThrow(
   "workflowDnsName"
@@ -40,7 +41,9 @@ async function getAllPinboards() {
   const fields = ["id", "title", "composerId"].join(",");
 
   const stubsResponse = await fetch(
-    `${WORKFLOW_DATASTORE_API_URL}/stubs?fieldFilter=${fields}`
+    `${WORKFLOW_DATASTORE_API_URL}/stubs?fieldFilter=${fields}&limit=${
+      MAX_PINBOARDS_TO_DISPLAY + 1
+    }`
   );
 
   if (!stubsResponse.ok) {


### PR DESCRIPTION
…where it was previously trying to render over 9k `OpenPinboardButton`s.

## What does this change?

In addition to limiting locally also limit on the server side (making use of https://github.com/guardian/workflow/pull/1093).

### More than 25 results
<img width="349" alt="image" src="https://user-images.githubusercontent.com/19289579/157009660-a769d420-2570-4902-b2a7-be571249d25a.png">

### Less than 25 results (via filter)
<img width="281" alt="image" src="https://user-images.githubusercontent.com/19289579/157009785-d9501e22-2032-43dd-be59-af8d90f9dafe.png">
