### PR TITLE
workflow server side search

### DIFF
--- a/client/gql.ts
+++ b/client/gql.ts
@@ -7,8 +7,8 @@ const pinboardReturnFields = `
   title
 `;
 export const gqlListPinboards = gql`
-  query MyQuery {
-    listPinboards { ${pinboardReturnFields} }
+  query MyQuery($searchText: String) {
+    listPinboards(searchText: $searchText) { ${pinboardReturnFields} }
   }
 `;
 export const gqlGetPinboardByComposerId = gql`

--- a/client/package.json
+++ b/client/package.json
@@ -22,6 +22,7 @@
     "@guardian/source-react-components-development-kitchen": "^0.0.33",
     "@sentry/react": "^6.18.1",
     "@webscopeio/react-textarea-autocomplete": "4.9.1",
+    "apollo-link-debounce": "^3.0.0",
     "aws-appsync-auth-link": "^3.0.7",
     "aws-appsync-subscription-link": "^3.0.9",
     "date-fns": "^2.19.0",

--- a/client/src/entry.tsx
+++ b/client/src/entry.tsx
@@ -13,8 +13,11 @@ import * as SentryHub from "@sentry/hub";
 import { onError } from "@apollo/client/link/error";
 import { GIT_COMMIT_HASH } from "../../GIT_COMMIT_HASH";
 import { BUILD_NUMBER } from "../../BUILD_NUMBER";
+import DebounceLink from "apollo-link-debounce";
 
 const SENTRY_REROUTED_FLAG = "rerouted";
+
+const DEFAULT_APOLLO_DEBOUNCE_DELAY = 0; // zero in-case used by mistake
 
 export function mount({
   userEmail,
@@ -100,6 +103,7 @@ export function mount({
 
   const apolloClient = new ApolloClient({
     link: ApolloLink.from([
+      new DebounceLink(DEFAULT_APOLLO_DEBOUNCE_DELAY), // order is important
       apolloErrorLink,
       createAuthLink(apolloUrlInfo),
       createSubscriptionHandshakeLink(apolloUrlInfo),

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -85,9 +85,9 @@ type Query {
     nextToken: String
   ): UserConnection
 
-  listPinboards: [WorkflowStub]
+  listPinboards(searchText: String): [WorkflowStub]
 
-  getPinboardByComposerId(composerId: String): WorkflowStub
+  getPinboardByComposerId(composerId: String!): WorkflowStub
 }
 
 type Subscription {

--- a/workflow-bridge-lambda/src/index.ts
+++ b/workflow-bridge-lambda/src/index.ts
@@ -7,10 +7,12 @@ const WORKFLOW_DATASTORE_API_URL = `http://${getEnvironmentVariableOrThrow(
   "workflowDnsName"
 )}/api`;
 
-exports.handler = async (event: { arguments?: { composerId?: string } }) => {
+exports.handler = async (event: {
+  arguments?: { composerId?: string; searchText?: string };
+}) => {
   return await (event.arguments?.composerId
     ? getPinboardByComposerId(event.arguments?.composerId)
-    : getAllPinboards());
+    : getAllPinboards(event.arguments?.searchText));
 };
 
 async function getPinboardByComposerId(composerId: string) {
@@ -37,13 +39,17 @@ async function getPinboardByComposerId(composerId: string) {
   return { ...data, status: data.externalData?.status };
 }
 
-async function getAllPinboards() {
+async function getAllPinboards(searchText?: string) {
   const fields = ["id", "title", "composerId"].join(",");
+
+  const searchQueryParamClause = searchText
+    ? `&text=${encodeURI(searchText)}`
+    : "";
 
   const stubsResponse = await fetch(
     `${WORKFLOW_DATASTORE_API_URL}/stubs?fieldFilter=${fields}&limit=${
       MAX_PINBOARDS_TO_DISPLAY + 1
-    }`
+    }${searchQueryParamClause}`
   );
 
   if (!stubsResponse.ok) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3746,6 +3746,11 @@ anymatch@^3.0.3, anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+apollo-link-debounce@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/apollo-link-debounce/-/apollo-link-debounce-3.0.0.tgz#39a82a5d0e53ece75a67f56d7c50d9a122631787"
+  integrity sha512-Ytig2Ml41T2bovBIoKkStPKoIh0r/kTK1dSM9Gpvo5W3BAPxt1WguAkeaPLJqeuvrNJIjQ/Pl38/14VVA0hdYg==
+
 archiver-utils@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/archiver-utils/-/archiver-utils-2.1.0.tgz#e8a460e94b693c3e3da182a098ca6285ba9249e2"


### PR DESCRIPTION
## What does this change?
- Passes the existing ` searchText` (from client-side filtering) into the the `listPinboards` GraphQL Query, making use of [`apollo-link-debounce`](https://www.npmjs.com/package/apollo-link-debounce) to avoid too frequent calls (on every key-press).
- via a new `searchText` input on the `listPinboards` GraphQL Query (in the `schema.graphql`)
- this`searchText` argument is then recieved by `workflow-bridge-lambda` and passed to the `workflow` API call via the (existing) `text` query parameter (which searches across notes, headline and working title - see https://github.com/guardian/workflow/blob/b95c45e1669f37765c5defc5b11ecafcc5212507/datastore/app/query/Query.scala#L81-L85)

## How to test
With this branch deployed to CODE (since local uses CODE AppSync) - search for various pinboards and observe the network requests in the Network tab of Developer Tools.

## How can we measure success?
This is a necessity for PROD, to allow us to find pinboards amongst the 9k plus results (without having to return them all to the client).
