### PR TITLE
polling (on workflow calls)

### DIFF
--- a/cdk/stack.ts
+++ b/cdk/stack.ts
@@ -418,6 +418,14 @@ export class PinBoardStack extends Stack {
       ),
     });
 
+    pinboardWorkflowBridgeLambdaDataSource.createResolver({
+      typeName: "Query",
+      fieldName: "getPinboardsByIds",
+      responseMappingTemplate: resolverBugWorkaround(
+        appsync.MappingTemplate.lambdaResult()
+      ),
+    });
+
     const removePushNotificationSecretsFromUserResponseMappingTemplate = appsync
       .MappingTemplate.fromString(`
         #set($output = $ctx.result)

--- a/client/gql.ts
+++ b/client/gql.ts
@@ -16,6 +16,11 @@ export const gqlGetPinboardByComposerId = gql`
     getPinboardByComposerId(composerId: $composerId) { ${pinboardReturnFields} }
   }
 `;
+export const gqlGetPinboardsByIds = gql`
+  query MyQuery($ids: [String!]!) {
+    getPinboardsByIds(ids: $ids) { ${pinboardReturnFields} }
+  }
+`;
 
 const itemReturnFields = `
   id

--- a/client/src/navigation/index.tsx
+++ b/client/src/navigation/index.tsx
@@ -4,7 +4,6 @@ import { pinboard } from "../../colours";
 import { palette, space } from "@guardian/source-foundations";
 import { agateSans } from "../../fontNormaliser";
 import { useGlobalStateContext } from "../globalState";
-import { PinboardData } from "../pinboard";
 import type { Tab } from "../types/Tab";
 import { BackArrowIcon, CrossIcon } from "./icon";
 import { NavButton } from "./button";
@@ -12,15 +11,15 @@ import { NavButton } from "./button";
 interface NavigationProps {
   activeTab: Tab;
   setActiveTab: (tab: Tab) => void;
-  selectedPinboard: PinboardData | undefined;
+  selectedPinboardId: string | null | undefined;
   clearSelectedPinboard: () => void;
 }
 export const Navigation = (props: PropsWithChildren<NavigationProps>) => {
   const { setIsExpanded, hasUnreadOnOtherPinboard } = useGlobalStateContext();
   // TODO replace with notification count when we have it
   const unreadNotificationCountOnOtherPinboard =
-    props.selectedPinboard &&
-    hasUnreadOnOtherPinboard(props.selectedPinboard.id)
+    props.selectedPinboardId &&
+    hasUnreadOnOtherPinboard(props.selectedPinboardId)
       ? 0
       : undefined;
   return (
@@ -43,7 +42,7 @@ export const Navigation = (props: PropsWithChildren<NavigationProps>) => {
           align-items: center;
         `}
       >
-        {props.selectedPinboard && (
+        {props.selectedPinboardId && (
           <NavButton
             onClick={props.clearSelectedPinboard}
             icon={BackArrowIcon}

--- a/client/src/panel.tsx
+++ b/client/src/panel.tsx
@@ -16,6 +16,7 @@ export const Panel: React.FC = () => {
   const {
     isExpanded,
     activePinboards,
+    activePinboardIds,
     selectedPinboardId,
     preselectedPinboard,
     clearSelectedPinboard,
@@ -24,14 +25,18 @@ export const Panel: React.FC = () => {
   const [activeTab, setActiveTab] = useState<Tab>(ChatTab);
 
   const selectedPinboard = activePinboards.find(
-    (ap) => ap.id === selectedPinboardId
+    (activePinboard) => activePinboard.id === selectedPinboardId
   );
 
-  const title =
-    selectedPinboard?.title ||
-    (preselectedPinboard === "notTrackedInWorkflow"
-      ? "No pinboard"
-      : "Select a pinboard");
+  const title = (() => {
+    if (selectedPinboardId) {
+      return selectedPinboard?.title || "Loading pinboard...";
+    }
+    if (preselectedPinboard === "notTrackedInWorkflow") {
+      return "No pinboard";
+    }
+    return "Select a pinboard";
+  })();
 
   return (
     <div
@@ -73,7 +78,7 @@ export const Panel: React.FC = () => {
       <Navigation
         activeTab={activeTab}
         setActiveTab={setActiveTab}
-        selectedPinboard={selectedPinboard}
+        selectedPinboardId={selectedPinboardId}
         clearSelectedPinboard={clearSelectedPinboard}
       >
         {title}
@@ -88,12 +93,12 @@ export const Panel: React.FC = () => {
       {
         // The active pinboards are always mounted, so that we receive new item notifications
         // Note that the pinboard hides itself based on 'isSelected' prop
-        activePinboards.map((pinboardData) => (
+        activePinboardIds.map((pinboardId) => (
           <Pinboard
-            pinboardData={pinboardData}
-            key={pinboardData.id}
-            isExpanded={pinboardData.id === selectedPinboardId && isExpanded}
-            isSelected={pinboardData.id === selectedPinboardId}
+            key={pinboardId}
+            pinboardId={pinboardId}
+            isExpanded={pinboardId === selectedPinboardId && isExpanded}
+            isSelected={pinboardId === selectedPinboardId}
             panelElement={panelRef.current}
           />
         ))

--- a/client/src/pinboard.tsx
+++ b/client/src/pinboard.tsx
@@ -1,10 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useQuery, useSubscription } from "@apollo/client";
-import {
-  Item,
-  LastItemSeenByUser,
-  WorkflowStub,
-} from "../../shared/graphql/graphql";
+import { Item, LastItemSeenByUser } from "../../shared/graphql/graphql";
 import { ScrollableItems } from "./scrollableItems";
 import { PendingItem } from "./types/PendingItem";
 import {
@@ -18,21 +14,19 @@ import { useGlobalStateContext } from "./globalState";
 import { css } from "@emotion/react";
 import { palette } from "@guardian/source-foundations";
 
-export type PinboardData = WorkflowStub;
-
 export interface LastItemSeenByUserLookup {
   [userEmail: string]: LastItemSeenByUser;
 }
 
 interface PinboardProps {
-  pinboardData: PinboardData;
+  pinboardId: string;
   isExpanded: boolean;
   isSelected: boolean;
   panelElement: HTMLDivElement | null;
 }
 
 export const Pinboard: React.FC<PinboardProps> = ({
-  pinboardData,
+  pinboardId,
   isExpanded,
   isSelected,
   panelElement,
@@ -50,8 +44,6 @@ export const Pinboard: React.FC<PinboardProps> = ({
 
     setUnreadFlag,
   } = useGlobalStateContext();
-
-  const pinboardId = pinboardData.id;
 
   // TODO: extract to floaty level?
   const itemSubscription = useSubscription(gqlOnCreateItem(pinboardId), {

--- a/shared/graphql/extraTypes.ts
+++ b/shared/graphql/extraTypes.ts
@@ -1,12 +1,16 @@
 import type { WorkflowStub } from "./graphql";
 
+export type PinboardData = WorkflowStub;
+
 export type PreselectedPinboard =
-  | WorkflowStub
+  | PinboardData
   | "loading"
   | "notTrackedInWorkflow"
   | undefined;
 
-export const isWorkflowStub = (
-  stub: PreselectedPinboard
-): stub is WorkflowStub =>
-  !!stub && stub !== "loading" && stub !== "notTrackedInWorkflow";
+export const isPinboardData = (
+  maybePinboardData: PreselectedPinboard
+): maybePinboardData is PinboardData =>
+  !!maybePinboardData &&
+  maybePinboardData !== "loading" &&
+  maybePinboardData !== "notTrackedInWorkflow";

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -86,7 +86,7 @@ type Query {
   ): UserConnection
 
   listPinboards(searchText: String): [WorkflowStub]
-
+  getPinboardsByIds(ids: [String!]!): [WorkflowStub]
   getPinboardByComposerId(composerId: String!): WorkflowStub
 }
 


### PR DESCRIPTION
## What does this change?

This configures _polling_ (every 5s) for `listPinboards` GraphQL Query **to keep working titles etc. relatively up to date**. Whilst polling can be enabled/configured with a single `pollingInterval` property on the useQuery, this would have been running constantly regardless of whether pinboard was being used, which is very wasteful, so instead we watch for when `isExpanded` changes and if it is expanded then we refetch immediately then start polling, and if collapsed then we stop polling.

The same has been applied to the `getPinboardByComposerId` query, but not only dependent on `isExpanded`, but also the `selectedPinboardId`.

Also added a new query for `activePinboards` at the top level (since these may no longer be in the search results following [limiting](https://github.com/guardian/editorial-tools-pinboard/pull/90) & [server-side search](https://github.com/guardian/editorial-tools-pinboard/pull/92)). This also has polling configured just like the above, but not only dependent on `isExpanded`, but also the `activePinboardIds`.

Plus a few refactors to stop passing whole `PinboardData` objects around, in favour of just passing pinboard IDs to ensure working title etc. always derive from the place that's being polled.

## How to test
With this branch deployed to CODE (since local uses CODE AppSync) - whilst viewing...
- search results
- a manually opened pinboard (e.g. in grid)
- a preselected pinboard (i.e. in a composer article which is tracked in workflow)

... try changing the working title in workflow and see it update in pinboard within 5 seconds.

Also notice that when pinboard is collapsed it is not polling (via the Network tab of Developer Tools).

## How can we measure success?
For users with long lived tabs, they'll need an up to date working title on everything - this PR achieves that.
