### PR TITLE
display headline as well as working title on `SelectPinboard`

### DIFF
--- a/client/gql.ts
+++ b/client/gql.ts
@@ -5,6 +5,7 @@ const pinboardReturnFields = `
   id
   status
   title
+  headline
 `;
 export const gqlListPinboards = gql`
   query MyQuery($searchText: String!) {

--- a/client/src/navigation/index.tsx
+++ b/client/src/navigation/index.tsx
@@ -13,6 +13,7 @@ interface NavigationProps {
   setActiveTab: (tab: Tab) => void;
   selectedPinboardId: string | null | undefined;
   clearSelectedPinboard: () => void;
+  headingTooltipText: string | undefined;
 }
 export const Navigation = (props: PropsWithChildren<NavigationProps>) => {
   const { setIsExpanded, hasUnreadOnOtherPinboard } = useGlobalStateContext();
@@ -41,6 +42,7 @@ export const Navigation = (props: PropsWithChildren<NavigationProps>) => {
           height: 24px;
           align-items: center;
         `}
+        title={props.headingTooltipText}
       >
         {props.selectedPinboardId && (
           <NavButton

--- a/client/src/panel.tsx
+++ b/client/src/panel.tsx
@@ -8,6 +8,7 @@ import { neutral, space } from "@guardian/source-foundations";
 import { Navigation } from "./navigation";
 import { ChatTab, Tab as Tab } from "./types/Tab";
 import { useGlobalStateContext } from "./globalState";
+import { getTooltipText } from "./util";
 
 const cornerSize = 24;
 
@@ -80,6 +81,9 @@ export const Panel: React.FC = () => {
         setActiveTab={setActiveTab}
         selectedPinboardId={selectedPinboardId}
         clearSelectedPinboard={clearSelectedPinboard}
+        headingTooltipText={
+          selectedPinboard && getTooltipText(selectedPinboard)
+        }
       >
         {title}
       </Navigation>

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -8,6 +8,7 @@ import isToday from "date-fns/isToday";
 import isYesterday from "date-fns/isYesterday";
 import differenceInHours from "date-fns/differenceInHours";
 import differenceInCalendarWeeks from "date-fns/differenceInCalendarWeeks";
+import { PinboardData } from "../../shared/graphql/extraTypes";
 
 export const userToMentionHandle = (user: User) =>
   `@${user.firstName} ${user.lastName}`;
@@ -41,3 +42,7 @@ export const formattedDateTime = (timestamp: number): string => {
     return format(timestamp, "d MMM yyyy HH:mm");
   }
 };
+
+export const getTooltipText = (pinboardData: PinboardData) =>
+  `WT: ${pinboardData.title}` +
+  (pinboardData.headline ? `\nHL: ${pinboardData.headline}` : "");

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -39,6 +39,7 @@ type UserWithHasWebPushSubscription {
 type WorkflowStub {
   id: String!
   title: String
+  headline: String
   composerId: String
   status: String
 }

--- a/workflow-bridge-lambda/src/index.ts
+++ b/workflow-bridge-lambda/src/index.ts
@@ -43,11 +43,11 @@ const getPinboardById = (apiBase: "content" | "stubs") => async (
   if (!data) {
     return null;
   }
-  return { ...data, status: data.externalData?.status };
+  return { ...data.externalData, ...data };
 };
 
 const getAllPinboards = async (searchText?: string) => {
-  const fields = ["id", "title", "composerId"].join(",");
+  const fields = ["id", "title", "composerId", "headline"].join(",");
 
   const searchQueryParamClause = searchText
     ? `&text=${encodeURI(searchText)}`


### PR DESCRIPTION
Previously we only exposed the working title from workflow to identify pinboards, but since #92 we're actually searching on headline as well as working title, so this presents a confusing set of search results for the user.

## What does this change?
This displays the headline (prefixed with`HL: ` - as per convention in workflow-frontend) or working title (prefixed with `WT: `) depending on which has the matches from `searchText`.
<img width="286" alt="image" src="https://user-images.githubusercontent.com/19289579/158174751-fa0fbc05-8b68-4180-bb79-0f72e2d6d742.png">

We also display a tooltip on both 'search results' and the 'heading of a pinboard' to display the working title and headline (where it's set), prefixed accordingly.
<img width="281" alt="image" src="https://user-images.githubusercontent.com/19289579/158174859-eae170b2-df99-42f5-9bd6-529852f55188.png"> <img width="299" alt="image" src="https://user-images.githubusercontent.com/19289579/158174914-b0108fb3-4d75-47d3-b953-1c58c4edb2d9.png">

## How to test
With this branch deployed to CODE (since local uses CODE AppSync), search for some pieces based on their headline and see results a bit like the above. Also hover over any search result or 'heading of a pinboard'.