### PR TITLE
persist `manuallyOpenedPinboardIds`, synced between tabs etc via subscription PLUS extra desktop notifications

### DIFF
--- a/cdk/stack.ts
+++ b/cdk/stack.ts
@@ -464,6 +464,52 @@ export class PinBoardStack extends Stack {
     });
 
     pinboardUserDataSource.createResolver({
+      typeName: "Mutation",
+      fieldName: "addManuallyOpenedPinboardIds",
+      requestMappingTemplate: resolverBugWorkaround(
+        appsync.MappingTemplate.fromString(`
+        {
+          "version": "2017-02-28",
+          "operation": "UpdateItem",
+          "key" : {
+            "email" : $util.dynamodb.toDynamoDBJson($ctx.identity.resolverContext.userEmail)
+          },
+          "update" : {
+            "expression" : "ADD manuallyOpenedPinboardIds :manuallyOpenedPinboardIds",
+            "expressionValues": {
+              ":manuallyOpenedPinboardIds" : $util.dynamodb.toStringSetJson($ctx.args.ids)
+            }
+          }
+        }
+      `)
+      ),
+      responseMappingTemplate: removePushNotificationSecretsFromUserResponseMappingTemplate,
+    });
+
+    pinboardUserDataSource.createResolver({
+      typeName: "Mutation",
+      fieldName: "removeManuallyOpenedPinboardIds",
+      requestMappingTemplate: resolverBugWorkaround(
+        appsync.MappingTemplate.fromString(`
+        {
+          "version": "2017-02-28",
+          "operation": "UpdateItem",
+          "key" : {
+            "email" : $util.dynamodb.toDynamoDBJson($ctx.identity.resolverContext.userEmail)
+          },
+          "update" : {
+            "expression" : "DELETE manuallyOpenedPinboardIds :manuallyOpenedPinboardIds",
+            "expressionValues": {
+              ":manuallyOpenedPinboardIds" : $util.dynamodb.toStringSetJson($ctx.args.ids)
+            }
+          }
+        }
+      `)
+      ),
+      responseMappingTemplate: removePushNotificationSecretsFromUserResponseMappingTemplate,
+    });
+
+    pinboardUserDataSource.createResolver({
       typeName: "Query",
       fieldName: "getMyUser",
       requestMappingTemplate: resolverBugWorkaround(

--- a/client/gql.ts
+++ b/client/gql.ts
@@ -73,8 +73,9 @@ const userReturnFields = `
   avatarUrl
 `;
 
-const userReturnFieldsWithHasWebPushSubscription = `${userReturnFields}
+const myUserReturnFields = `${userReturnFields}
   hasWebPushSubscription
+  manuallyOpenedPinboardIds
 `;
 
 export const gqlGetAllUsers = gql`
@@ -88,7 +89,7 @@ query MyQuery {
 export const gqlGetMyUser = gql`
 query MyQuery {
   getMyUser {
-    ${userReturnFieldsWithHasWebPushSubscription}
+    ${myUserReturnFields}
   }
 }
 `;
@@ -96,9 +97,34 @@ query MyQuery {
 export const gqlSetWebPushSubscriptionForUser = gql`
   mutation SetWebPushSubscriptionForUser($webPushSubscription: AWSJSON) {
     setWebPushSubscriptionForUser(webPushSubscription: $webPushSubscription) {
-      ${userReturnFieldsWithHasWebPushSubscription}
+      ${myUserReturnFields}
     }
   }
+`;
+
+export const gqlAddManuallyOpenedPinboardIds = gql`
+  mutation AddManuallyOpenedPinboardIds($ids: [String!]!) {
+    addManuallyOpenedPinboardIds(ids: $ids) {
+      # including fields here makes them accessible in our subscription data
+      ${myUserReturnFields}
+    }
+  }
+`;
+export const gqlRemoveManuallyOpenedPinboardIds = gql`
+  mutation RemoveManuallyOpenedPinboardIds($ids: [String!]!) {
+    removeManuallyOpenedPinboardIds(ids: $ids) {
+      # including fields here makes them accessible in our subscription data
+      ${myUserReturnFields}
+    }
+  }
+`;
+
+export const gqlOnManuallyOpenedPinboardIdsChanged = (userEmail: string) => gql`
+    subscription OnManuallyOpenedPinboardIdsChanged {
+        onManuallyOpenedPinboardIdsChanged(email: "${userEmail}") { 
+            ${myUserReturnFields} 
+        }
+    }
 `;
 
 const lastItemSeenByUserReturnFields = `

--- a/shared/graphql/aws.graphql
+++ b/shared/graphql/aws.graphql
@@ -1,2 +1,4 @@
 scalar AWSJSON
 scalar AWSTimestamp
+
+directive @aws_subscribe(mutations: [String!]!) on FIELD_DEFINITION

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -28,12 +28,13 @@ type User {
   lastName: String!
   avatarUrl: String
 }
-type UserWithHasWebPushSubscription {
+type MyUser {
   email: String!
   firstName: String!
   lastName: String!
   avatarUrl: String
   hasWebPushSubscription: Boolean
+  manuallyOpenedPinboardIds: [String!]
 }
 
 type WorkflowStub {
@@ -62,7 +63,9 @@ type LastItemSeenByUserConnection {
 type Mutation {
   createItem(input: CreateItemInput!): Item
   seenItem(input: LastItemSeenByUserInput!): LastItemSeenByUser
-  setWebPushSubscriptionForUser(webPushSubscription: AWSJSON): UserWithHasWebPushSubscription
+  setWebPushSubscriptionForUser(webPushSubscription: AWSJSON): MyUser
+  addManuallyOpenedPinboardIds(ids: [String!]!): MyUser
+  removeManuallyOpenedPinboardIds(ids: [String!]!): MyUser
 }
 
 type Query {
@@ -78,7 +81,7 @@ type Query {
     nextToken: String
   ): LastItemSeenByUserConnection
 
-  getMyUser: UserWithHasWebPushSubscription
+  getMyUser: MyUser
 
   searchUsers(
     filter: TableUserFilterInput
@@ -95,9 +98,14 @@ type Subscription {
   onCreateItem(
     pinboardId: String
   ): Item @aws_subscribe(mutations: ["createItem"])
+
   onSeenItem(
     pinboardId: String!
   ): LastItemSeenByUser @aws_subscribe(mutations: ["seenItem"])
+
+  onManuallyOpenedPinboardIdsChanged(
+    email: String! # unfortunately this can't be done via 'identity' in the resolver
+  ): MyUser @aws_subscribe(mutations: ["addManuallyOpenedPinboardIds", "removeManuallyOpenedPinboardIds"])
 }
 
 input CreateItemInput {


### PR DESCRIPTION
## What does this change?
Previously the list of 'open pinboards' was maintained purely on the client (and therefore lost on refresh). This PR persists the list (`manuallyOpenedPinboardIds` to be specific) on a new column on the user table, via a new GraphQL query and mutation (making use of DynamoDB string set operators [`ADD`](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.ADD) and [`DELETE`](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.DELETE)). We also keep this live using a new GraphQL subscription.

With this information persisted we can now start sending push notifications for any message (to a user has the pinboard 'open' and has subscribed to push notifications obviously) rather than just for mentions.

## How to test
With this branch deployed to CODE (since local uses CODE AppSync) - try opening two tabs (say https://composer.code.dev-gutools.co.uk and https://media.test.dev-gutools.co.uk) open a pinboard in one tab and see it appear in the other tab. Similarly, close the tabs then open either again and you should see same opened pinboards.