### PR TITLE
Fix the script include in the register service worker

### DIFF
--- a/client/webpack.service-worker.config.js
+++ b/client/webpack.service-worker.config.js
@@ -3,6 +3,7 @@ const HtmlWebpackPlugin = require("html-webpack-plugin");
 
 module.exports = {
   entry: {
+    // ensure this key matches the "chunks" list in the html webpack plugin config below
     registerServiceWorker: "./src/push-notifications/registerServiceWorker.ts",
     serviceWorker: "./src/push-notifications/serviceWorker.ts",
   },
@@ -31,7 +32,7 @@ module.exports = {
   },
   plugins: [
     new HtmlWebpackPlugin({
-      chunks: ["register"],
+      chunks: ["registerServiceWorker"],
       template: "./src/push-notifications/index.html",
       scriptLoading: "blocking",
     }),


### PR DESCRIPTION
Co-authored-by: @twrichards 

## What does this change?

Re-includes the register service worker bundle in the push notifications config page as originally intended for #71 

## How to test

Script tag exists on the push-notifications page
