### PR TITLE
Round the relative timestamps consistently

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,8 @@
     "build-service-worker": "webpack --config webpack.service-worker.config.js --mode=production",
     "watch-service-worker": "webpack --config webpack.service-worker.config.js --mode=development --watch",
     "watch": "run-p --print-label watch-type-check watch-main-client watch-service-worker",
-    "build": "run-p --print-label type-check build-main-client build-service-worker"
+    "build": "run-p --print-label type-check build-main-client build-service-worker",
+    "test": "jest 2>&1"
   },
   "dependencies": {
     "@apollo/client": "^3.5.5",

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -19,9 +19,13 @@ export const formattedDateTime = (timestamp: number): string => {
       if (differenceInMinutes(now, timestamp) < 1) {
         return "Now";
       } else if (differenceInMinutes(now, timestamp) === 1) {
-        return formatDistanceStrict(timestamp, now).slice(0, -3);
+        return formatDistanceStrict(timestamp, now, {
+          roundingMethod: "floor",
+        }).slice(0, -3);
       } else if (differenceInHours(now, timestamp) < 1) {
-        return formatDistanceStrict(timestamp, now).slice(0, -4);
+        return formatDistanceStrict(timestamp, now, {
+          roundingMethod: "floor",
+        }).slice(0, -4);
       }
       return format(timestamp, "HH:mm");
     } else if (isYesterday(timestamp)) {

--- a/client/test/formattedDateTime.test.ts
+++ b/client/test/formattedDateTime.test.ts
@@ -1,6 +1,7 @@
 import subDays from "date-fns/subDays";
 import subHours from "date-fns/subHours";
 import subMinutes from "date-fns/subMinutes";
+import subSeconds from "date-fns/subSeconds";
 import subYears from "date-fns/subYears";
 
 import { formattedDateTime } from "../src/util";
@@ -17,7 +18,14 @@ test("display is correct if timestamp is 1 min ago exactly", () => {
   expect(formattedDateTime(oneMinAgo)).toBe("1 min");
 });
 
-test("display is correct if timestamp is between 1 min and 1 hr ago", () => {
+test("display is correct if timestamp is between 1 min and 2 mins ago", () => {
+  const almostTwoMinsAgo = subSeconds(Date.now(), 95).valueOf();
+  expect(formattedDateTime(almostTwoMinsAgo)).toBe("1 min");
+});
+
+test("display is correct if timestamp is between 2 min and 1 hr ago", () => {
+  const twoMinsAgo = subMinutes(Date.now(), 2).valueOf();
+  expect(formattedDateTime(twoMinsAgo)).toBe("2 min");
   const lessThanHr = subMinutes(Date.now(), 59).valueOf();
   expect(formattedDateTime(lessThanHr)).toBe("59 min");
 });

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "watch-client": "yarn --cwd 'client' watch 2>&1",
     "watch-bootstrapping-lambda": "yarn --cwd 'bootstrapping-lambda' watch 2>&1",
     "watch": "run-p --print-label watch-client watch-bootstrapping-lambda",
-    "test": "yarn --cwd 'client' jest 2>&1",
+    "test": "yarn workspace client test",
     "build": "wsrun --parallel --fast-exit --prefix --report build ",
     "prepare": "husky install"
   },


### PR DESCRIPTION
Co-authored-by: Tom Richards <tom.richards@guardian.co.uk>

## What does this change?

There was an edge case in timestamps between 1 and 2 mins - after 1.30, the minutes count reads `1` but the formatter would round to 2 mins, so when we slice down `minutes` down to `min` we end up off by one and displaying `2 minu`! This fixes by making the formatter round down, so from 1 min until 1.59 we'll display `1 min`, from 2 mins until 2.59 we'll display `2 min` etc.

## How to test

run the test suite