### PR TITLE
Implement asset view

### DIFF
--- a/client/src/assetView.tsx
+++ b/client/src/assetView.tsx
@@ -1,0 +1,70 @@
+import { css } from "@emotion/react";
+import { neutral, palette, space } from "@guardian/source-foundations";
+import React from "react";
+import { scrollbarsCss } from "./styling";
+import type { Item } from "../../shared/graphql/graphql";
+import type { PendingItem } from "./types/PendingItem";
+import { PayloadDisplay } from "./payloadDisplay";
+import type { Payload, PayloadAndType } from "./types/PayloadAndType";
+
+interface AssetView {
+  initialItems: (Item | PendingItem)[];
+  successfulSends: PendingItem[];
+  subscriptionItems: Item[];
+}
+
+export const AssetView: React.FC<AssetView> = ({
+  initialItems,
+  successfulSends,
+  subscriptionItems,
+}) => {
+  const payloadsMap: PayloadAndType[] = [
+    ...initialItems,
+    ...successfulSends,
+    ...subscriptionItems,
+  ]
+    .sort((a, b) => a.timestamp - b.timestamp)
+    .reduce((accumulator, item) => {
+      if (!item.payload) {
+        return accumulator;
+      }
+      const payload = JSON.parse(item.payload) as Payload;
+      const payloadAndType = { type: item.type, payload };
+      return payload.embeddableUrl &&
+        payload.thumbnail &&
+        !accumulator.some(
+          (other) =>
+            other.payload.embeddableUrl === payloadAndType.payload.embeddableUrl
+        )
+        ? [...accumulator, payloadAndType]
+        : accumulator;
+    }, [] as PayloadAndType[]);
+
+  return (
+    <div
+      css={css`
+        overflow-y: auto;
+        ${scrollbarsCss(palette.neutral[60])}
+        padding: ${space[2]}px;
+        position: relative;
+      `}
+    >
+      {payloadsMap.map(({ type, payload }) => (
+        <div
+          key={payload.thumbnail}
+          css={css`
+            margin: ${space[1]}px;
+            border: 1px solid ${neutral[86]};
+            border-radius: ${space[1]}px;
+            max-width: fit-content;
+            &:hover {
+              background-color: ${neutral[86]};
+            }
+          `}
+        >
+          <PayloadDisplay type={type} payload={payload} />
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/client/src/globalState.tsx
+++ b/client/src/globalState.tsx
@@ -18,15 +18,17 @@ import {
 import { EXPAND_PINBOARD_QUERY_PARAM } from "./app";
 import type { PayloadAndType } from "./types/PayloadAndType";
 import type { PerPinboard } from "./types/PerPinboard";
-import type {
-  PinboardData,
-  PreselectedPinboard,
-} from "../../shared/graphql/extraTypes";
+import type { PinboardData } from "../../shared/graphql/extraTypes";
 import { isPinboardData } from "../../shared/graphql/extraTypes";
+import type { PreselectedPinboard } from "../../shared/graphql/extraTypes";
+import { ChatTab, Tab } from "./types/Tab";
 
 interface GlobalStateContextShape {
   userEmail: string;
   userLookup: { [email: string]: User } | undefined;
+
+  activeTab: Tab;
+  setActiveTab: (tab: Tab) => void;
 
   activePinboardIds: string[];
   activePinboards: PinboardData[];
@@ -108,6 +110,8 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
   clearDesktopNotificationsForPinboardId,
   children,
 }) => {
+  const [activeTab, setActiveTab] = useState<Tab>(ChatTab);
+
   const [getPreselectedPinboard, preselectedPinboardQuery] = useLazyQuery(
     gqlGetPinboardByComposerId
   );
@@ -325,6 +329,9 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
   const contextValue: GlobalStateContextShape = {
     userEmail,
     userLookup,
+
+    activeTab,
+    setActiveTab,
 
     activePinboards,
     activePinboardIds,

--- a/client/src/itemDisplay.tsx
+++ b/client/src/itemDisplay.tsx
@@ -64,7 +64,6 @@ interface ItemDisplayProps {
   timestampLastRefreshed: number;
   seenBy: LastItemSeenByUser[] | undefined;
   maybePreviousItem: Item | PendingItem | undefined;
-  maybeNextItem: Item | PendingItem | undefined;
 }
 
 export const ItemDisplay = ({

--- a/client/src/navigation/index.tsx
+++ b/client/src/navigation/index.tsx
@@ -7,6 +7,7 @@ import { useGlobalStateContext } from "../globalState";
 import type { Tab } from "../types/Tab";
 import { BackArrowIcon, CrossIcon } from "./icon";
 import { NavButton } from "./button";
+import { Tabs } from "./tabs";
 
 interface NavigationProps {
   activeTab: Tab;
@@ -66,14 +67,13 @@ export const Navigation = (props: PropsWithChildren<NavigationProps>) => {
         <NavButton onClick={() => setIsExpanded(false)} icon={CrossIcon} />
       </div>
 
-      {/* TODO re-enable tabs when we implement & enable asset view */}
-      {/* {props.selectedPinboard && (
+      {props.selectedPinboardId && (
         <Tabs
           activeTab={props.activeTab}
           setActiveTab={props.setActiveTab}
           unreadMessages={null} // ready for when we have unread messages count to display
         />
-      )} */}
+      )}
     </div>
   );
 };

--- a/client/src/panel.tsx
+++ b/client/src/panel.tsx
@@ -1,12 +1,11 @@
 import { css } from "@emotion/react";
-import React, { useRef, useState } from "react";
+import React, { useRef } from "react";
 import { bottom, boxShadow, floatySize, right } from "./styling";
 import { NotTrackedInWorkflow } from "./notTrackedInWorkflow";
 import { Pinboard } from "./pinboard";
 import { SelectPinboard } from "./selectPinboard";
 import { neutral, space } from "@guardian/source-foundations";
 import { Navigation } from "./navigation";
-import { ChatTab, Tab as Tab } from "./types/Tab";
 import { useGlobalStateContext } from "./globalState";
 import { getTooltipText } from "./util";
 
@@ -21,9 +20,9 @@ export const Panel: React.FC = () => {
     selectedPinboardId,
     preselectedPinboard,
     clearSelectedPinboard,
+    activeTab,
+    setActiveTab,
   } = useGlobalStateContext();
-
-  const [activeTab, setActiveTab] = useState<Tab>(ChatTab);
 
   const selectedPinboard = activePinboards.find(
     (activePinboard) => activePinboard.id === selectedPinboardId

--- a/client/src/pinboard.tsx
+++ b/client/src/pinboard.tsx
@@ -13,6 +13,7 @@ import { SendMessageArea } from "./sendMessageArea";
 import { useGlobalStateContext } from "./globalState";
 import { css } from "@emotion/react";
 import { palette } from "@guardian/source-foundations";
+import { AssetView } from "./assetView";
 
 export interface LastItemSeenByUserLookup {
   [userEmail: string]: LastItemSeenByUser;
@@ -32,6 +33,7 @@ export const Pinboard: React.FC<PinboardProps> = ({
   panelElement,
 }) => {
   const {
+    activeTab,
     userEmail,
     userLookup,
 
@@ -157,7 +159,7 @@ export const Pinboard: React.FC<PinboardProps> = ({
           flex-grow: 1;
         `}
       />
-      {initialItems.data && (
+      {activeTab === "chat" && initialItems.data && (
         <ScrollableItems
           showNotification={showNotification}
           initialItems={initialItems.data.listItems.items}
@@ -171,16 +173,25 @@ export const Pinboard: React.FC<PinboardProps> = ({
           lastItemSeenByUserLookup={lastItemSeenByUserLookup}
         />
       )}
-      <SendMessageArea
-        onSuccessfulSend={onSuccessfulSend}
-        payloadToBeSent={payloadToBeSent}
-        clearPayloadToBeSent={clearPayloadToBeSent}
-        allUsers={userLookup && Object.values(userLookup)}
-        onError={(error) => setError(pinboardId, error)}
-        userEmail={userEmail}
-        pinboardId={pinboardId}
-        panelElement={panelElement}
-      />
+      {activeTab === "asset" && initialItems.data && (
+        <AssetView
+          initialItems={initialItems.data.listItems.items}
+          successfulSends={successfulSends}
+          subscriptionItems={subscriptionItems}
+        />
+      )}
+      {activeTab === "chat" && (
+        <SendMessageArea
+          onSuccessfulSend={onSuccessfulSend}
+          payloadToBeSent={payloadToBeSent}
+          clearPayloadToBeSent={clearPayloadToBeSent}
+          allUsers={userLookup && Object.values(userLookup)}
+          onError={(error) => setError(pinboardId, error)}
+          userEmail={userEmail}
+          pinboardId={pinboardId}
+          panelElement={panelElement}
+        />
+      )}
     </React.Fragment>
   );
 };

--- a/client/src/scrollableItems.tsx
+++ b/client/src/scrollableItems.tsx
@@ -211,7 +211,6 @@ export const ScrollableItems = ({
           timestampLastRefreshed={timestampLastRefreshed}
           seenBy={lastItemSeenByUsersForItemIDLookup[item.id]}
           maybePreviousItem={items[index - 1]}
-          maybeNextItem={items[index + 1]}
         />
       ))}
       {hasUnread && (

--- a/client/src/types/PayloadAndType.ts
+++ b/client/src/types/PayloadAndType.ts
@@ -1,4 +1,4 @@
-type Payload = {
+export type Payload = {
   thumbnail?: string;
   embeddableUrl?: string;
 }; // & Record<string, string | undefined>


### PR DESCRIPTION
## What does this change?

Adds in the asset view

I've chosen to implement by adding a new component to control the asset view, rather than reusing `ScrollableItems` (thoough I did also spike that implementation, which is on the [an/asset-view-2](https://github.com/guardian/editorial-tools-pinboard/compare/3ca2c...an/asset-view-2) branch.)

Pros:
- Code has a minimal footprint - all of the changes are limited to this new component and the `Pinboard` component. Reusing `ScrollableItems` means that several components would need to be aware of which tab has been selected and modify their behaviour/appearance based on that. eg. There is no modification to `ItemDisplay`.
- Asset view does not interfere with the unread notifications system. Using `ScrollableItems`, if you were at the bottom of the asset view when a new text only message arrived, the unread notification dot would be dismissed, despite not being able to see the message.
- It's easier to deduplicate images in the asset view.

Cons:
- Some of the code from `ScrollableItems` is duplicated (styling, merging of items from various sources)
- Some behaviour from `ScrollableItems` has not been replicated (though could be added again in the future), such as scrolling to the bottom of the panel on load.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![image](https://user-images.githubusercontent.com/10963046/158401805-38d9dce2-dc25-488a-85b6-909f8aa8dddb.png)

