### PR TITLE
ensure `manuallyOpenedPinboardIds` are updated on `createItem` (for sender and all those who are mentioned)

### DIFF
--- a/cdk/stack.ts
+++ b/cdk/stack.ts
@@ -472,7 +472,12 @@ export class PinBoardStack extends Stack {
           "version": "2017-02-28",
           "operation": "UpdateItem",
           "key" : {
-            "email" : $util.dynamodb.toDynamoDBJson($ctx.identity.resolverContext.userEmail)
+            "email" : $util.dynamodb.toDynamoDBJson(
+              $util.defaultIfNull(
+                $ctx.args.maybeEmailOverride,
+                $ctx.identity.resolverContext.userEmail
+              )
+            )
           },
           "update" : {
             "expression" : "ADD manuallyOpenedPinboardIds :manuallyOpenedPinboardIds",

--- a/client/gql.ts
+++ b/client/gql.ts
@@ -103,8 +103,8 @@ export const gqlSetWebPushSubscriptionForUser = gql`
 `;
 
 export const gqlAddManuallyOpenedPinboardIds = gql`
-  mutation AddManuallyOpenedPinboardIds($ids: [String!]!) {
-    addManuallyOpenedPinboardIds(ids: $ids) {
+  mutation AddManuallyOpenedPinboardIds($ids: [String!]!, $maybeEmailOverride: String) {
+    addManuallyOpenedPinboardIds(ids: $ids, maybeEmailOverride: $maybeEmailOverride) {
       # including fields here makes them accessible in our subscription data
       ${myUserReturnFields}
     }

--- a/client/src/globalState.tsx
+++ b/client/src/globalState.tsx
@@ -1,5 +1,6 @@
 import {
   ApolloError,
+  FetchResult,
   useLazyQuery,
   useMutation,
   useQuery,
@@ -33,6 +34,10 @@ interface GlobalStateContextShape {
   payloadToBeSent: PayloadAndType | null;
   clearPayloadToBeSent: () => void;
 
+  addManuallyOpenedPinboardId: (
+    pinboardId: string,
+    maybeEmailOverride?: string
+  ) => Promise<FetchResult<{ addManuallyOpenedPinboardIds: MyUser }>>;
   openPinboard: (pinboardData: PinboardData, isOpenInNewTab: boolean) => void;
   closePinboard: (pinboardId: string) => void;
   preselectedPinboard: PreselectedPinboard;
@@ -175,6 +180,17 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     addManuallyOpenedPinboardIds: MyUser;
   }>(gqlAddManuallyOpenedPinboardIds);
 
+  const addManuallyOpenedPinboardId = (
+    pinboardId: string,
+    maybeEmailOverride?: string
+  ) =>
+    addManuallyOpenedPinboardIds({
+      variables: {
+        ids: [pinboardId],
+        maybeEmailOverride,
+      },
+    });
+
   const openPinboard = (
     pinboardData: PinboardData,
     isOpenInNewTab: boolean
@@ -195,11 +211,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     }
 
     if (!activePinboardIds.includes(pinboardData.id)) {
-      addManuallyOpenedPinboardIds({
-        variables: {
-          ids: [pinboardData.id],
-        },
-      }).then(
+      addManuallyOpenedPinboardId(pinboardData.id).then(
         (result) =>
           result.data
             ? setManuallyOpenedPinboardIds(
@@ -320,6 +332,7 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     payloadToBeSent,
     clearPayloadToBeSent,
 
+    addManuallyOpenedPinboardId,
     openPinboard,
     closePinboard,
     preselectedPinboard,

--- a/client/src/pinboard.tsx
+++ b/client/src/pinboard.tsx
@@ -43,6 +43,8 @@ export const Pinboard: React.FC<PinboardProps> = ({
     setError,
 
     setUnreadFlag,
+
+    addManuallyOpenedPinboardId,
   } = useGlobalStateContext();
 
   // TODO: extract to floaty level?
@@ -126,6 +128,18 @@ export const Pinboard: React.FC<PinboardProps> = ({
     [initialItems.error, itemSubscription.error]
   );
 
+  const onSuccessfulSend = (pendingItem: PendingItem) => {
+    setSuccessfulSends((previousSends) => [...previousSends, pendingItem]);
+
+    // ensure any pinboard you contribute to ends up on your list of manually opened pinboards
+    addManuallyOpenedPinboardId(pendingItem.pinboardId);
+
+    // ensure any pinboard you're mentioned on ends up on your list of manually opened pinboards
+    pendingItem.mentions?.map((mentionEmail) =>
+      addManuallyOpenedPinboardId(pendingItem.pinboardId, mentionEmail)
+    );
+  };
+
   return !isSelected ? null : (
     <React.Fragment>
       {initialItems.loading && "Loading..."}
@@ -158,9 +172,7 @@ export const Pinboard: React.FC<PinboardProps> = ({
         />
       )}
       <SendMessageArea
-        onSuccessfulSend={(pendingItem) =>
-          setSuccessfulSends((previousSends) => [...previousSends, pendingItem])
-        }
+        onSuccessfulSend={onSuccessfulSend}
         payloadToBeSent={payloadToBeSent}
         clearPayloadToBeSent={clearPayloadToBeSent}
         allUsers={userLookup && Object.values(userLookup)}

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -64,7 +64,7 @@ type Mutation {
   createItem(input: CreateItemInput!): Item
   seenItem(input: LastItemSeenByUserInput!): LastItemSeenByUser
   setWebPushSubscriptionForUser(webPushSubscription: AWSJSON): MyUser
-  addManuallyOpenedPinboardIds(ids: [String!]!): MyUser
+  addManuallyOpenedPinboardIds(ids: [String!]!, maybeEmailOverride: String): MyUser
   removeManuallyOpenedPinboardIds(ids: [String!]!): MyUser
 }
 


### PR DESCRIPTION
Since #90 and #92 we had no way of showing that you had been mentioned on a pinboard beyond the one(s) you have open. 

## What does this change?
Now we have #97 we can ensure when someone is mentioned the pinboard is added to their <img width="87" alt="image" src="https://user-images.githubusercontent.com/19289579/158418716-1828158c-76b6-4ee0-918e-9222e7f84bc9.png"> (i.e. `manuallyOpenedPinboardIds`).

Similarly, if you're in a composer article (i.e. pinboard is pre-selected) then as soon as you send a message, the pinboard will be added to your <img width="87" alt="image" src="https://user-images.githubusercontent.com/19289579/158418716-1828158c-76b6-4ee0-918e-9222e7f84bc9.png"> (i.e. `manuallyOpenedPinboardIds`) so that it will then appear elsewhere (i.e. grid) and you will start recieving desktop notifications even after your close the tab (assuming you've subscribed to desktop notifications obviously).

## How to test
With this branch deployed to CODE (since local uses CODE AppSync)...

- open up grid in one tab, expanding pinboard
- you should open an article in composer [which is tracked in workflow] but that you don't yet have in your <img width="87" alt="image" src="https://user-images.githubusercontent.com/19289579/158418716-1828158c-76b6-4ee0-918e-9222e7f84bc9.png"> - which should appear with the heading <img width="227" alt="image" src="https://user-images.githubusercontent.com/19289579/158420238-1a701609-feb1-457b-916a-ca3cfae9bd30.png">
- send a message on that pinboard
- you should see the pinboard appear in your <img width="87" alt="image" src="https://user-images.githubusercontent.com/19289579/158418716-1828158c-76b6-4ee0-918e-9222e7f84bc9.png"> in grid