### PR TITLE
Style the error message

### DIFF
--- a/client/colours.ts
+++ b/client/colours.ts
@@ -3,6 +3,7 @@ import { palette } from "@guardian/source-foundations";
 export const pinMetal = palette.neutral[20]; //"#333333"
 export const composer = {
   warning: {
+    [100]: "#A51B08",
     [300]: "#C7291C",
   } as const,
   primary: {

--- a/client/src/floaty.tsx
+++ b/client/src/floaty.tsx
@@ -6,6 +6,7 @@ import { palette, space } from "@guardian/source-foundations";
 import { agateSans } from "../fontNormaliser";
 import { bottom, boxShadow, floatySize, right } from "./styling";
 import { useGlobalStateContext } from "./globalState";
+import { SvgAlertTriangle } from "@guardian/source-react-components";
 
 interface FloatyNotificationsBubbleProps {
   presetUnreadNotificationCount: number | undefined;
@@ -43,6 +44,32 @@ export const Floaty: React.FC = () => {
     hasError,
     hasUnread,
   } = useGlobalStateContext();
+
+  const badge = (() => {
+    if (hasError) {
+      return (
+        <div
+          css={css`
+            position: absolute;
+            top: -4px;
+            fill: ${composer.warning[100]};
+            right: -4px;
+            user-select: none;
+          `}
+        >
+          <SvgAlertTriangle size="xsmall" />
+        </div>
+      );
+    }
+    if (presetUnreadNotificationCount !== undefined || hasUnread) {
+      return (
+        <FloatyNotificationsBubble
+          presetUnreadNotificationCount={presetUnreadNotificationCount}
+        />
+      );
+    }
+  })();
+
   return (
     <div
       css={css`
@@ -76,25 +103,7 @@ export const Floaty: React.FC = () => {
           }
         `}
       />
-      {hasError && (
-        <div
-          css={css`
-            position: absolute;
-            font-size: ${floatySize / 4}px;
-            bottom: -${floatySize / 16}px;
-            right: 0px;
-            user-select: none;
-            text-shadow: 0 0 5px black;
-          `}
-        >
-          ⚠️
-        </div>
-      )}
-      {(presetUnreadNotificationCount !== undefined || hasUnread) && (
-        <FloatyNotificationsBubble
-          presetUnreadNotificationCount={presetUnreadNotificationCount}
-        />
-      )}
+      {badge}
     </div>
   );
 };

--- a/client/src/panel.tsx
+++ b/client/src/panel.tsx
@@ -1,6 +1,12 @@
 import { css } from "@emotion/react";
 import React, { useRef } from "react";
-import { bottom, boxShadow, floatySize, right } from "./styling";
+import {
+  bottom,
+  boxShadow,
+  floatySize,
+  panelCornerSize,
+  right,
+} from "./styling";
 import { NotTrackedInWorkflow } from "./notTrackedInWorkflow";
 import { Pinboard } from "./pinboard";
 import { SelectPinboard } from "./selectPinboard";
@@ -8,8 +14,6 @@ import { neutral, space } from "@guardian/source-foundations";
 import { Navigation } from "./navigation";
 import { useGlobalStateContext } from "./globalState";
 import { getTooltipText } from "./util";
-
-const cornerSize = 24;
 
 export const Panel: React.FC = () => {
   const panelRef = useRef<HTMLDivElement>(null);
@@ -50,9 +54,9 @@ export const Panel: React.FC = () => {
         min-height: 380px;
         max-height: min(
           800px,
-          calc(98vh - ${bottom + floatySize + space[4] + cornerSize}px)
+          calc(98vh - ${bottom + floatySize + space[4] + panelCornerSize}px)
         );
-        bottom: ${bottom + floatySize + space[2] + cornerSize}px;
+        bottom: ${bottom + floatySize + space[2] + panelCornerSize}px;
         right: ${right + floatySize / 2}px;
         display: ${isExpanded ? "flex" : "none"};
         flex-direction: column;
@@ -64,11 +68,11 @@ export const Panel: React.FC = () => {
           content: "";
           position: fixed;
           background: ${neutral[93]};
-          width: ${cornerSize}px;
-          height: ${cornerSize}px;
+          width: ${panelCornerSize}px;
+          height: ${panelCornerSize}px;
           bottom: ${bottom + floatySize + space[2]}px;
           right: ${right + floatySize / 2}px;
-          border-bottom-left-radius: ${cornerSize}px;
+          border-bottom-left-radius: ${panelCornerSize}px;
           box-shadow: ${boxShadow};
           clip: rect(0, 50px, 50px, -25px); // clip off the top of the shadow
         }

--- a/client/src/pinboard.tsx
+++ b/client/src/pinboard.tsx
@@ -12,7 +12,11 @@ import {
 import { SendMessageArea } from "./sendMessageArea";
 import { useGlobalStateContext } from "./globalState";
 import { css } from "@emotion/react";
-import { palette } from "@guardian/source-foundations";
+import { palette, space } from "@guardian/source-foundations";
+import { composer } from "../colours";
+import { SvgAlertTriangle } from "@guardian/source-react-components";
+import { agateSans } from "../fontNormaliser";
+import { bottom, floatySize, panelCornerSize, right } from "./styling";
 import { AssetView } from "./assetView";
 
 export interface LastItemSeenByUserLookup {
@@ -42,6 +46,7 @@ export const Pinboard: React.FC<PinboardProps> = ({
 
     showNotification,
 
+    errors,
     setError,
 
     setUnreadFlag,
@@ -129,6 +134,7 @@ export const Pinboard: React.FC<PinboardProps> = ({
     () => setError(pinboardId, initialItems.error || itemSubscription.error),
     [initialItems.error, itemSubscription.error]
   );
+  const hasError = !!errors[pinboardId];
 
   const onSuccessfulSend = (pendingItem: PendingItem) => {
     setSuccessfulSends((previousSends) => [...previousSends, pendingItem]);
@@ -145,15 +151,65 @@ export const Pinboard: React.FC<PinboardProps> = ({
   return !isSelected ? null : (
     <React.Fragment>
       {initialItems.loading && "Loading..."}
-      <div
-        css={css`
-          background-color: ${palette.opinion[500]};
-          color: ${palette.neutral[100]};
-        `}
-      >
-        {initialItems.error && `Error: ${initialItems.error}`}
-        {itemSubscription.error && `Error: ${itemSubscription.error}`}
-      </div>
+      {hasError && (
+        <div
+          css={css`
+            position: absolute;
+            top: 58px;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            z-index: 98;
+            border-top-left-radius: ${space[1]}px;
+            border-top-right-radius: ${space[1]}px;
+            background-color: rgba(255, 255, 255, 0.35);
+            &::after {
+              content: "";
+              position: fixed;
+              background: rgba(255, 255, 255, 0.35);
+              width: ${panelCornerSize}px;
+              height: ${panelCornerSize}px;
+              bottom: ${bottom + floatySize + space[2]}px;
+              right: ${right + floatySize / 2}px;
+              border-bottom-left-radius: ${panelCornerSize}px;
+            }
+          `}
+        >
+          <div
+            css={css`
+              background-color: ${composer.warning[100]};
+              color: ${palette.neutral[100]};
+              ${agateSans.xsmall({ lineHeight: "tight", fontWeight: "bold" })}
+              padding: ${space[2]}px;
+              border-radius: ${space[1]}px;
+              margin: ${space[2]}px;
+              position: relative;
+              top: 0;
+              z-index: 99;
+            `}
+          >
+            <div
+              css={css`
+                display: flex;
+                align-items: center;
+                column-gap: ${space[2]}px;
+              `}
+            >
+              <div
+                css={css`
+                  fill: ${palette.neutral[100]};
+                `}
+              >
+                <SvgAlertTriangle size="small" />
+              </div>
+              <div>
+                There has been an error. You may need to refresh the page to
+                allow pinboard to reconnect. Make sure to save your work first!
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
       <div // push chat messages to bottom of panel if they do not fill
         css={css`
           flex-grow: 1;

--- a/client/src/styling.ts
+++ b/client/src/styling.ts
@@ -45,3 +45,5 @@ export const scrollbarsCss = (fg: string) => css`
     border-radius: 999px;
   }
 `;
+
+export const panelCornerSize = 24;


### PR DESCRIPTION
## What does this change?

Adds styling for the error message.

![image](https://user-images.githubusercontent.com/10963046/158561505-0b340b01-6778-4f84-be95-e1e68b3203ff.png)


The overlay does not cover the navigation, which is still usable.

![image](https://user-images.githubusercontent.com/10963046/158432899-5136c908-44ce-4afe-ba05-95d799ef93d3.png)


## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
