### PR TITLE
`stopPropagation` of keyPress for search box on `SelectPinboard` (a.k.a. index list)

### DIFF
--- a/client/src/selectPinboard.tsx
+++ b/client/src/selectPinboard.tsx
@@ -302,7 +302,8 @@ export const SelectPinboard: React.FC = () => {
             label="Search"
             hideLabel
             value={searchText}
-            onChange={(e) => setSearchText(e.target.value)}
+            onChange={(event) => setSearchText(event.target.value)}
+            onKeyPress={(event) => event.stopPropagation()}
             placeholder="Search by Working Title / Headline"
             css={{
               marginBottom: "5px",


### PR DESCRIPTION
key presses in the search box of `SelectPinboard` (a.k.a. index list) were triggering keyboard shortcuts in grid. The PR prevents that with `stopPropagation` (much like we do on the message input box).