### PR TITLE
ensure 'scroll to last item' button marks the last item as 'seen' when there is no scroll bar

### DIFF
--- a/client/src/scrollableItems.tsx
+++ b/client/src/scrollableItems.tsx
@@ -30,7 +30,7 @@ interface ScrollableItemsProps {
 }
 
 const isScrollbarVisible = (scrollableArea: HTMLDivElement) =>
-  scrollableArea.scrollHeight >= scrollableArea.clientHeight;
+  scrollableArea.scrollHeight > scrollableArea.clientHeight;
 
 const elementIsVisible = (
   scrollableArea: HTMLDivElement,
@@ -223,7 +223,11 @@ export const ScrollableItems = ({
           `}
         >
           <button
-            onClick={scrollToLastItem}
+            onClick={() =>
+              scrollableArea && isScrollbarVisible(scrollableArea)
+                ? scrollToLastItem()
+                : seenLastItem()
+            }
             css={css`
               fill: white;
               background-color: ${palette.neutral[20]};


### PR DESCRIPTION
Fixes a nasty little bug, where 'scroll to last item' button did nothing when there was no scroll bar, when really it should be marking the last item as 'seen'. Note, it only got into this start if the user was not focussed on the tab containing pinboard when the message was received (rightly so, to prevent messages being missed).