### PR TITLE
consolidate the 'seen by' tooltip to just be a list of all 'seen by's

### DIFF
--- a/client/src/avatarRoundel.tsx
+++ b/client/src/avatarRoundel.tsx
@@ -9,18 +9,20 @@ interface AvatarRoundelProps {
   maybeUser: User | undefined;
   size: number;
   userEmail: string;
-  tooltipSuffix?: string;
+  shouldHideTooltip?: true;
 }
 
 export const AvatarRoundel = ({
   maybeUser,
   size,
   userEmail,
-  tooltipSuffix,
+  shouldHideTooltip,
 }: AvatarRoundelProps) => {
-  const tooltip = `${
-    maybeUser ? `${maybeUser.firstName} ${maybeUser.lastName}` : userEmail
-  }${tooltipSuffix || ""}`;
+  const tooltip = shouldHideTooltip
+    ? undefined
+    : `${
+        maybeUser ? `${maybeUser.firstName} ${maybeUser.lastName}` : userEmail
+      }`;
 
   return maybeUser?.avatarUrl ? (
     <img

--- a/client/src/seenBy.tsx
+++ b/client/src/seenBy.tsx
@@ -17,15 +17,15 @@ interface SeenByProps {
 }
 
 export const SeenBy = ({ seenBy, userLookup }: SeenByProps) => {
-  const hiddenUsernames = seenBy
-    .slice(maxSeenByIcons)
+  const tooltip = seenBy
     .map(({ seenAt, userEmail }) => {
       const user = userLookup?.[userEmail];
       const name = user ? `${user.firstName} ${user.lastName}` : userEmail;
 
-      return `${name} ${formattedDateTime(seenAt * 1000)}`;
+      return `${name} (${formattedDateTime(seenAt * 1000)})`;
     })
-    .join(", ");
+    .join("\n");
+
   return (
     <div
       css={css`
@@ -33,6 +33,7 @@ export const SeenBy = ({ seenBy, userLookup }: SeenByProps) => {
         align-items: center;
         justify-content: flex-end;
       `}
+      title={tooltip}
     >
       <span
         css={css`
@@ -56,7 +57,7 @@ export const SeenBy = ({ seenBy, userLookup }: SeenByProps) => {
             maybeUser={userLookup?.[userEmail]}
             size={roundelHeightPx}
             userEmail={userEmail}
-            tooltipSuffix={` ${formattedDateTime(seenAt * 1000)}`}
+            shouldHideTooltip
           />
         </div>
       ))}
@@ -74,7 +75,6 @@ export const SeenBy = ({ seenBy, userLookup }: SeenByProps) => {
                 align-items: center;
               }
             `}
-            title={hiddenUsernames}
           >
             <SvgPlus size="xsmall" />
           </span>


### PR DESCRIPTION
… (rather than per avatar) with the time in brackets to separate it. Since I found it hard to hover specifically on each avatar and then the plus separately.

| Before | After |
| --- | --- | 
| ![image](https://user-images.githubusercontent.com/19289579/158583887-7d9514a3-350a-4d64-a88c-9a1c66a43314.png) | ![image](https://user-images.githubusercontent.com/19289579/158583799-b54b0a69-eba1-4da7-812f-b1794ece07bb.png) |