### PR TITLE
Fix overflowing usernames and emails

### DIFF
--- a/client/src/avatarRoundel.tsx
+++ b/client/src/avatarRoundel.tsx
@@ -45,6 +45,7 @@ export const AvatarRoundel = ({
         background-color: ${composer.primary[300]};
         color: ${neutral[100]};
         display: flex;
+        flex-shrink: 0;
         user-select: none;
         justify-content: center;
         align-items: center;

--- a/client/src/itemDisplay.tsx
+++ b/client/src/itemDisplay.tsx
@@ -100,6 +100,7 @@ export const ItemDisplay = ({
         font-style: ${isPendingSend ? "italic" : "normal"};
         ${agateSans.small({ lineHeight: "tight" })};
         color: ${palette.neutral[20]};
+        overflow-wrap: anywhere;
       `}
     >
       <div
@@ -131,7 +132,6 @@ export const ItemDisplay = ({
       <div
         css={css`
           margin-left: ${space[9] - 4}px;
-          overflow-wrap: break-word;
         `}
       >
         <div


### PR DESCRIPTION
## What does this change?

Moves word breaking css rule up to top of item display, so that usernames (and emails) are included. To also encompass emails, we must use `overflow-wrap: anywhere` to encourage the browser to break the word. Ideally the word would be broken at the `@`, but there doesn't seem to be that ability in CSS.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

Before: 
![image](https://user-images.githubusercontent.com/10963046/158596240-5bb29cd1-693b-45f3-8dc0-efb3564c95d3.png)

After:
![image](https://user-images.githubusercontent.com/10963046/158596270-e170bb02-8df0-428e-8cc7-b4c1818ae387.png)
