### PR TITLE
FIX: filter out users with missing `firstName` or `lastName`

### DIFF
--- a/cdk/stack.ts
+++ b/cdk/stack.ts
@@ -435,8 +435,22 @@ export class PinBoardStack extends Stack {
 
     pinboardUserDataSource.createResolver({
       typeName: "Query",
-      fieldName: "searchUsers",
-      requestMappingTemplate: dynamoFilterRequestMappingTemplate,
+      fieldName: "listUsers",
+      requestMappingTemplate: resolverBugWorkaround(
+        appsync.MappingTemplate.fromString(`
+        {
+          "version": "2017-02-28",
+          "operation": "Scan",
+          "filter": {
+            "expression": "attribute_exists(#firstName) AND attribute_exists(#lastName)",
+            "expressionNames": {
+              "#firstName": "firstName",
+              "#lastName": "lastName",
+            },
+          },
+        }
+      `)
+      ),
       responseMappingTemplate: dynamoFilterResponseMappingTemplate,
     });
 

--- a/client/gql.ts
+++ b/client/gql.ts
@@ -79,11 +79,11 @@ const myUserReturnFields = `${userReturnFields}
 `;
 
 export const gqlGetAllUsers = gql`
-query MyQuery {
-  searchUsers {
-    items { ${userReturnFields} }
-  }
-}
+    query MyQuery {
+        listUsers {
+            items { ${userReturnFields} }
+        }
+    }
 `;
 
 export const gqlGetMyUser = gql`

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -149,7 +149,7 @@ export const PinBoardApp = ({ apolloClient, userEmail }: PinBoardAppProps) => {
   const usersQuery = useQuery(gqlGetAllUsers, { client: apolloClient });
   //TODO: make use of usersQuery.error and usersQuery.loading
 
-  const allUsers: User[] | undefined = usersQuery.data?.searchUsers.items;
+  const allUsers: User[] | undefined = usersQuery.data?.listUsers.items;
 
   const userLookup = allUsers?.reduce(
     (lookup, user) => ({

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -83,8 +83,7 @@ type Query {
 
   getMyUser: MyUser
 
-  searchUsers(
-    filter: TableUserFilterInput
+  listUsers(
     limit: Int
     nextToken: String
   ): UserConnection


### PR DESCRIPTION
As of #103  when someone sends a message, we now up**sert** the `manuallyOpenedPinboardIds` field on their user record. Which means there can be partial user records (i.e. lacking `firstName` and `lastName`) between when the user is added and when the `user-refresher-lambda` next runs on its schedule. When querying the user table (which is done on load in pinboard, to build the `userLookup` the query errors because any partial user records won't conform to the GraphQL schema, and as such the `userLookup` won't get populated and no names or avatars will be displayed and just emails instead - looks awful. 

## What does this change?
- rename `searchUsers` to `listUsers`
- remove `filter` argument, so we can explicitly set a filter expression directly in the resolver (filter was unused anyway, possibly a bit broken and will get replaced soon when we move away from Dynamo to a relational DB)
- add the 'filter expression' to  filter out users with missing `firstName` or `lastName` (as this indicates user refresher has not run against them yet)

## How to test
In CODE, with this branch deployed, find the CODE users table, remove the `lastName` field on your user record and see how it no longer breaks the firstName, lastName and avatar for all users in a chat etc.
