### PR TITLE
filter out `null` workflow items (which happens when item is 'deleted automatically')

### DIFF
--- a/workflow-bridge-lambda/src/index.ts
+++ b/workflow-bridge-lambda/src/index.ts
@@ -14,7 +14,9 @@ exports.handler = async (event: {
     return await getPinboardById("content")(event.arguments.composerId);
   }
   if (event.arguments?.ids) {
-    return await Promise.all(event.arguments.ids.map(getPinboardById("stubs")));
+    return (
+      await Promise.all(event.arguments.ids.map(getPinboardById("stubs")))
+    ).filter((_) => !!_);
   } else {
     return await getAllPinboards(event.arguments?.searchText);
   }


### PR DESCRIPTION
temporary workaround so pinboard doesn't crash if people have 'my pinboards' which include items fully delete from workflow (which we think happens automatically)