### PR TITLE
FIX regression in `workflow-bridge-lambda` on lookup by composer ID

### DIFF
--- a/client/src/globalState.tsx
+++ b/client/src/globalState.tsx
@@ -120,7 +120,10 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     if (!preselectedComposerId) {
       return;
     }
-    if (preselectedPinboardQuery.data?.getPinboardByComposerId) {
+    if (
+      preselectedPinboardQuery.data?.getPinboardByComposerId &&
+      !preselectedPinboardQuery.data.getPinboardByComposerId.isNotFound
+    ) {
       return preselectedPinboardQuery.data.getPinboardByComposerId;
     }
     if (preselectedPinboardQuery.loading) {


### PR DESCRIPTION
FIX regression/oversight introduced in https://github.com/guardian/editorial-tools-pinboard/pull/117, by ignoring the result of `getPinboardByComposerId` if `isNotFound:true` (i.e. how we used to treat null)

This fix re-instates the correct 'No pinboard' behaviour 
![image](https://user-images.githubusercontent.com/19289579/160657196-4d74ce69-cba5-4891-b528-e4c83e849e1f.png)
