### PR TITLE
use `@types/aws-lambda` for lambda input events

### DIFF
--- a/auth-lambda/src/index.ts
+++ b/auth-lambda/src/index.ts
@@ -3,14 +3,15 @@ import { getPandaConfig } from "../../shared/panDomainAuth";
 import crypto from "crypto";
 import { standardAwsConfig } from "../../shared/awsIntegration";
 import * as AWS from "aws-sdk";
+import { AppSyncAuthorizerEvent } from "aws-lambda";
 
 const S3 = new AWS.S3(standardAwsConfig);
 
-exports.handler = async (event: {
-  authorizationToken?: string;
-  requestContext: unknown;
-}) => {
-  console.log(event.requestContext);
+exports.handler = async ({
+  authorizationToken,
+  requestContext,
+}: AppSyncAuthorizerEvent) => {
+  console.log(requestContext);
 
   const pandaConfig = await getPandaConfig<{ publicKey: string }>(S3);
 
@@ -19,8 +20,8 @@ exports.handler = async (event: {
   );
 
   const maybeAuthedUserEmail =
-    event.authorizationToken &&
-    (await jwtVerify(event.authorizationToken, publicKey)).payload["userEmail"];
+    authorizationToken &&
+    (await jwtVerify(authorizationToken, publicKey)).payload["userEmail"];
 
   // TODO is this sufficient? (does this expire after 1h or 90d)
   if (maybeAuthedUserEmail) {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@graphql-codegen/typescript": "1.17.11",
     "@graphql-codegen/typescript-resolvers": "1.17.11",
     "@guardian/node-riffraff-artifact": "0.3.2",
+    "@types/aws-lambda": "^8.10.93",
     "@typescript-eslint/eslint-plugin": "^4.11.1",
     "@typescript-eslint/parser": "^4.11.1",
     "esbuild": "^0.14.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2902,10 +2902,10 @@
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
-"@types/aws-lambda@*":
-  version "8.10.64"
-  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.64.tgz#4bdcb725aef96bef0cb1decf19c7efff1df22fe7"
-  integrity sha512-LRKk2UQCSi7BsO5TlfSI8cTNpOGz+MH6+RXEWtuZmxJficQgxwEYJDiKVirzgyiHce0L0F4CqCVvKTwblAeOUw==
+"@types/aws-lambda@*", "@types/aws-lambda@^8.10.93":
+  version "8.10.93"
+  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.93.tgz#3e2c80894122477040aabf29b7320556f5702a76"
+  integrity sha512-Vsyi9ogDAY3REZDjYnXMRJJa62SDvxHXxJI5nGDQdZW058dDE+av/anynN2rLKbCKXDRNw3D/sQmqxVflZFi4A==
 
 "@types/aws-serverless-express@^3.3.3":
   version "3.3.3"


### PR DESCRIPTION
Small refactor PR.

Makes sense to use `@types/aws-lambda` for lambda input events, rather than coding our own (partial) types.