### PR TITLE
run the `users-refresher-lambda` every minute 

### DIFF
--- a/cdk/stack.ts
+++ b/cdk/stack.ts
@@ -21,7 +21,7 @@ import * as ec2 from "@aws-cdk/aws-ec2";
 import * as events from "@aws-cdk/aws-events";
 import * as eventsTargets from "@aws-cdk/aws-events-targets";
 import { join } from "path";
-import { APP, userTableTTLAttribute } from "../shared/constants";
+import { APP } from "../shared/constants";
 import crypto from "crypto";
 import { DynamoEventSource } from "@aws-cdk/aws-lambda-event-sources";
 import { ENVIRONMENT_VARIABLE_KEYS } from "../shared/environmentVariables";
@@ -153,7 +153,6 @@ export class PinBoardStack extends Stack {
           name: "email",
           type: db.AttributeType.STRING,
         },
-        timeToLiveAttribute: userTableTTLAttribute,
         encryption: db.TableEncryption.DEFAULT,
       }
     );

--- a/cdk/stack.ts
+++ b/cdk/stack.ts
@@ -574,16 +574,32 @@ export class PinBoardStack extends Stack {
     );
     pinboardAppsyncUserTable.grantReadWriteData(usersRefresherLambdaFunction);
 
-    /*const usersRefresherLambdaSchedule =*/ new events.Rule(
+    new events.Rule(
       thisStack,
-      `${usersRefresherLambdaBasename}-schedule`,
+      `${usersRefresherLambdaBasename}-schedule-isProcessPermissionChangesOnly`,
       {
-        description: `Runs the ${usersRefresherLambdaFunction.functionName} every minute.`,
+        description: `Runs the ${usersRefresherLambdaFunction.functionName} every minute, with 'isProcessPermissionChangesOnly: true'.`,
+        enabled: true,
+        targets: [
+          new eventsTargets.LambdaFunction(usersRefresherLambdaFunction, {
+            event: events.RuleTargetInput.fromObject({
+              isProcessPermissionChangesOnly: true,
+            }),
+          }),
+        ],
+        schedule: events.Schedule.rate(Duration.minutes(1)),
+      }
+    );
+    new events.Rule(
+      thisStack,
+      `${usersRefresherLambdaBasename}-schedule-FULL-RUN`,
+      {
+        description: `Runs the ${usersRefresherLambdaFunction.functionName} every 24 hours, which should be a FULL RUN.`,
         enabled: true,
         targets: [
           new eventsTargets.LambdaFunction(usersRefresherLambdaFunction),
         ],
-        schedule: events.Schedule.rate(Duration.minutes(1)),
+        schedule: events.Schedule.rate(Duration.days(1)),
       }
     );
 

--- a/cdk/stack.ts
+++ b/cdk/stack.ts
@@ -579,12 +579,12 @@ export class PinBoardStack extends Stack {
       thisStack,
       `${usersRefresherLambdaBasename}-schedule`,
       {
-        description: `Runs the ${usersRefresherLambdaFunction.functionName} every 6 hours.`,
+        description: `Runs the ${usersRefresherLambdaFunction.functionName} every minute.`,
         enabled: true,
         targets: [
           new eventsTargets.LambdaFunction(usersRefresherLambdaFunction),
         ],
-        schedule: events.Schedule.rate(Duration.hours(6)),
+        schedule: events.Schedule.rate(Duration.minutes(1)),
       }
     );
 

--- a/cdk/test/__snapshots__/stack.test.ts.snap
+++ b/cdk/test/__snapshots__/stack.test.ts.snap
@@ -2483,7 +2483,7 @@ $util.toJson($ctx.result)",
       },
       "Type": "AWS::IAM::Policy",
     },
-    "pinboardusersrefresherlambdascheduleAllowEventRulePinBoardStackpinboardusersrefresherlambdaAD576B4A37874BE9": Object {
+    "pinboardusersrefresherlambdascheduleFULLRUNAllowEventRulePinBoardStackpinboardusersrefresherlambdaAD576B4AC502C51D": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
@@ -2495,14 +2495,14 @@ $util.toJson($ctx.result)",
         "Principal": "events.amazonaws.com",
         "SourceArn": Object {
           "Fn::GetAtt": Array [
-            "pinboardusersrefresherlambdascheduleD4D4DE02",
+            "pinboardusersrefresherlambdascheduleFULLRUNFB9A4F9E",
             "Arn",
           ],
         },
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "pinboardusersrefresherlambdascheduleD4D4DE02": Object {
+    "pinboardusersrefresherlambdascheduleFULLRUNFB9A4F9E": Object {
       "Properties": Object {
         "Description": Object {
           "Fn::Join": Array [
@@ -2512,11 +2512,11 @@ $util.toJson($ctx.result)",
               Object {
                 "Ref": "pinboardusersrefresherlambda2D488032",
               },
-              " every minute.",
+              " every 24 hours, which should be a FULL RUN.",
             ],
           ],
         },
-        "ScheduleExpression": "rate(1 minute)",
+        "ScheduleExpression": "rate(1 day)",
         "State": "ENABLED",
         "Targets": Array [
           Object {
@@ -2531,6 +2531,56 @@ $util.toJson($ctx.result)",
         ],
       },
       "Type": "AWS::Events::Rule",
+    },
+    "pinboardusersrefresherlambdascheduleisProcessPermissionChangesOnly403FC359": Object {
+      "Properties": Object {
+        "Description": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "Runs the ",
+              Object {
+                "Ref": "pinboardusersrefresherlambda2D488032",
+              },
+              " every minute, with 'isProcessPermissionChangesOnly: true'.",
+            ],
+          ],
+        },
+        "ScheduleExpression": "rate(1 minute)",
+        "State": "ENABLED",
+        "Targets": Array [
+          Object {
+            "Arn": Object {
+              "Fn::GetAtt": Array [
+                "pinboardusersrefresherlambda2D488032",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+            "Input": "{\\"isProcessPermissionChangesOnly\\":true}",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "pinboardusersrefresherlambdascheduleisProcessPermissionChangesOnlyAllowEventRulePinBoardStackpinboardusersrefresherlambdaAD576B4A41C988EE": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "pinboardusersrefresherlambda2D488032",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::GetAtt": Array [
+            "pinboardusersrefresherlambdascheduleisProcessPermissionChangesOnly403FC359",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
     },
     "pinboardusertable2621B03F": Object {
       "DeletionPolicy": "Retain",

--- a/cdk/test/__snapshots__/stack.test.ts.snap
+++ b/cdk/test/__snapshots__/stack.test.ts.snap
@@ -2511,11 +2511,11 @@ $util.toJson($ctx.result)",
               Object {
                 "Ref": "pinboardusersrefresherlambda2D488032",
               },
-              " every 6 hours.",
+              " every minute.",
             ],
           ],
         },
-        "ScheduleExpression": "rate(6 hours)",
+        "ScheduleExpression": "rate(1 minute)",
         "State": "ENABLED",
         "Targets": Array [
           Object {

--- a/cdk/test/__snapshots__/stack.test.ts.snap
+++ b/cdk/test/__snapshots__/stack.test.ts.snap
@@ -144,6 +144,7 @@ type User {
   firstName: String!
   lastName: String!
   avatarUrl: String
+  isMentionable: Boolean
 }
 type MyUser {
   email: String!
@@ -356,7 +357,7 @@ input TableStringFilterInput {
         "DataSourceName": "item_table_datasource",
         "FieldName": "createItem",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : c5c6b24ecb8b37d702718633ceddb3b9
+        "RequestMappingTemplate": "## schema checksum : 508353afffde3143882fbe5c89afc645
 
       #set($input = $ctx.args.input)
       $util.qr($input.put(\\"timestamp\\", $util.time.nowEpochSeconds()))
@@ -389,7 +390,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "item_table_datasource",
         "FieldName": "listItems",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : c5c6b24ecb8b37d702718633ceddb3b9
+        "RequestMappingTemplate": "## schema checksum : 508353afffde3143882fbe5c89afc645
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -523,7 +524,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "last_item_seen_by_user_table_datasource",
         "FieldName": "seenItem",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : c5c6b24ecb8b37d702718633ceddb3b9
+        "RequestMappingTemplate": "## schema checksum : 508353afffde3143882fbe5c89afc645
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -561,7 +562,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "last_item_seen_by_user_table_datasource",
         "FieldName": "listLastItemSeenByUsers",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : c5c6b24ecb8b37d702718633ceddb3b9
+        "RequestMappingTemplate": "## schema checksum : 508353afffde3143882fbe5c89afc645
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -695,7 +696,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "user_table_datasource",
         "FieldName": "addManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : c5c6b24ecb8b37d702718633ceddb3b9
+        "RequestMappingTemplate": "## schema checksum : 508353afffde3143882fbe5c89afc645
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -740,7 +741,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "user_table_datasource",
         "FieldName": "removeManuallyOpenedPinboardIds",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : c5c6b24ecb8b37d702718633ceddb3b9
+        "RequestMappingTemplate": "## schema checksum : 508353afffde3143882fbe5c89afc645
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -780,7 +781,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "user_table_datasource",
         "FieldName": "setWebPushSubscriptionForUser",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : c5c6b24ecb8b37d702718633ceddb3b9
+        "RequestMappingTemplate": "## schema checksum : 508353afffde3143882fbe5c89afc645
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -820,7 +821,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "user_table_datasource",
         "FieldName": "getMyUser",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : c5c6b24ecb8b37d702718633ceddb3b9
+        "RequestMappingTemplate": "## schema checksum : 508353afffde3143882fbe5c89afc645
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -854,7 +855,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "user_table_datasource",
         "FieldName": "listUsers",
         "Kind": "UNIT",
-        "RequestMappingTemplate": "## schema checksum : c5c6b24ecb8b37d702718633ceddb3b9
+        "RequestMappingTemplate": "## schema checksum : 508353afffde3143882fbe5c89afc645
 
         {
           \\"version\\": \\"2017-02-28\\",
@@ -994,7 +995,7 @@ $util.qr($input.put(\\"userEmail\\", $ctx.identity.resolverContext.userEmail))
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardByComposerId",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : c5c6b24ecb8b37d702718633ceddb3b9
+        "ResponseMappingTemplate": "## schema checksum : 508353afffde3143882fbe5c89afc645
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1015,7 +1016,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "getPinboardsByIds",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : c5c6b24ecb8b37d702718633ceddb3b9
+        "ResponseMappingTemplate": "## schema checksum : 508353afffde3143882fbe5c89afc645
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -1036,7 +1037,7 @@ $util.toJson($ctx.result)",
         "DataSourceName": "workflow_bridge_lambda_ds",
         "FieldName": "listPinboards",
         "Kind": "UNIT",
-        "ResponseMappingTemplate": "## schema checksum : c5c6b24ecb8b37d702718633ceddb3b9
+        "ResponseMappingTemplate": "## schema checksum : 508353afffde3143882fbe5c89afc645
 $util.toJson($ctx.result)",
         "TypeName": "Query",
       },
@@ -2568,10 +2569,6 @@ $util.toJson($ctx.result)",
             },
           },
         ],
-        "TimeToLiveSpecification": Object {
-          "AttributeName": "ttlEpochSeconds",
-          "Enabled": true,
-        },
       },
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Retain",

--- a/client/gql.ts
+++ b/client/gql.ts
@@ -83,7 +83,9 @@ const myUserReturnFields = `${userReturnFields}
 export const gqlGetAllUsers = gql`
     query MyQuery {
         listUsers {
-            items { ${userReturnFields} }
+            items { ${userReturnFields}
+                isMentionable
+            }
         }
     }
 `;

--- a/client/src/createItemInputBox.tsx
+++ b/client/src/createItemInputBox.tsx
@@ -19,8 +19,9 @@ const mentionsDataProvider = (allUsers: User[]) => (token: string) => {
   return allUsers
     ?.filter(
       (_) =>
-        _.firstName.toLowerCase().startsWith(tokenLower) ||
-        _.lastName.toLowerCase().startsWith(tokenLower)
+        _.isMentionable === true &&
+        (_.firstName.toLowerCase().startsWith(tokenLower) ||
+          _.lastName.toLowerCase().startsWith(tokenLower))
     )
     .slice(0, 5);
 };

--- a/notifications-lambda/src/index.ts
+++ b/notifications-lambda/src/index.ts
@@ -46,7 +46,11 @@ export const handler = async (event: DynamoDBStreamEvent) => {
         ExclusiveStartKey: startKey,
         ProjectionExpression:
           "email, webPushSubscription, manuallyOpenedPinboardIds",
-        FilterExpression: "attribute_exists(webPushSubscription)",
+        FilterExpression:
+          "attribute_exists(webPushSubscription) AND isMentionable = :isMentionable",
+        ExpressionAttributeValues: {
+          ":isMentionable": true,
+        },
       })
       .promise();
 

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -1,7 +1,5 @@
 export const APP = "pinboard";
 
-export const userTableTTLAttribute = "ttlEpochSeconds";
-
 export const publicVapidKey =
   "BAJ1E479bw4iqDH3nTg-OhzLw1daQ9Hfn6EY0x40M9AXGgEew4dBpAb_LE35plZ6YhU2VY87LLJtytE7hJKP9GM";
 

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -27,6 +27,7 @@ type User {
   firstName: String!
   lastName: String!
   avatarUrl: String
+  isMentionable: Boolean
 }
 type MyUser {
   email: String!

--- a/users-refresher-lambda/run.ts
+++ b/users-refresher-lambda/run.ts
@@ -1,3 +1,3 @@
 import { handler } from "./src";
 
-handler().then(console.log).catch(console.error);
+handler({}).then(console.log).catch(console.error);

--- a/users-refresher-lambda/src/index.ts
+++ b/users-refresher-lambda/src/index.ts
@@ -1,8 +1,4 @@
-import {
-  admin as googleAdminAPI,
-  admin_directory_v1,
-  auth as googleAuth,
-} from "@googleapis/admin";
+import { admin as googleAdminAPI, auth as googleAuth } from "@googleapis/admin";
 import { people as googlePeopleAPI } from "@googleapis/people";
 import * as AWS from "aws-sdk";
 import { standardAwsConfig } from "../../shared/awsIntegration";
@@ -12,71 +8,99 @@ import {
 } from "../../shared/panDomainAuth";
 import { p12ToPem } from "./p12ToPem";
 import { getPinboardPermissionOverrides } from "../../shared/permissions";
-import { userTableTTLAttribute } from "../../shared/constants";
 import { getEnvironmentVariableOrThrow } from "../../shared/environmentVariables";
 import { DocumentClient } from "aws-sdk/lib/dynamodb/document_client";
 
-const THREE_DAYS_IN_SECONDS = 60 * 60 * 24 * 3;
-
 const GUARDIAN_EMAIL_DOMAIN = "@guardian.co.uk";
+
+interface BasicUser {
+  resourceName?: string;
+  email: string;
+  firstName?: string;
+  lastName?: string;
+  isMentionable: boolean;
+}
 
 const S3 = new AWS.S3(standardAwsConfig);
 const dynamo = new AWS.DynamoDB.DocumentClient(standardAwsConfig);
 
 export const handler = async () => {
+  const now = new Date();
   const usersTableName = getEnvironmentVariableOrThrow("usersTableName");
+
+  const getStoredUsers = async (
+    startKey?: DocumentClient.Key
+  ): Promise<BasicUser[]> => {
+    const userResults = await dynamo
+      .scan({
+        TableName: usersTableName,
+        ExclusiveStartKey: startKey,
+        AttributesToGet: ["email", "isMentionable"],
+      })
+      .promise();
+
+    const storedUsers =
+      userResults.Items?.map((user) => user as BasicUser) || [];
+
+    if (userResults.LastEvaluatedKey) {
+      return [
+        ...storedUsers,
+        ...(await getStoredUsers(userResults.LastEvaluatedKey)),
+      ];
+    } else {
+      return storedUsers;
+    }
+  };
 
   const emailsOfUsersWithPinboardPermission = (
     await getPinboardPermissionOverrides(S3)
-  )?.reduce(
+  )?.reduce<string[]>(
     (acc, { userId, active }) => (active ? [...acc, userId] : acc),
-    [] as string[]
+    []
   );
 
   if (!emailsOfUsersWithPinboardPermission) {
     throw Error("Could not get list of users with 'pinboard' permission.");
   }
 
-  const now = new Date();
-  if (now.getHours() === 0 && now.getMinutes() === 0) {
-    console.log("NIGHTLY FULL RUN (primarily to bump TTLs)");
-  } else {
-    const getStoredUserEmails = async (
-      startKey?: DocumentClient.Key
-    ): Promise<string[]> => {
-      const userResults = await dynamo
-        .scan({
-          TableName: usersTableName,
-          ExclusiveStartKey: startKey,
-          AttributesToGet: ["email"],
-        })
-        .promise();
+  const isNightlyFullRun = now.getHours() === 0 && now.getMinutes() === 0;
 
-      const storedUserEmails =
-        userResults.Items?.map(({ email }) => email) || [];
+  const storedUsers = await getStoredUsers();
+  const storedUsersEmails = storedUsers.map(({ email }) => email);
 
-      if (userResults.LastEvaluatedKey) {
-        return [
-          ...storedUserEmails,
-          ...(await getStoredUserEmails(userResults.LastEvaluatedKey)),
-        ];
-      } else {
-        return storedUserEmails;
-      }
-    };
-
-    const storedUserEmails = await getStoredUserEmails();
-
-    const newUserEmails = emailsOfUsersWithPinboardPermission.filter(
-      (email) => !storedUserEmails.includes(email)
+  const basicUsersWherePinboardPermissionRemoved = storedUsers.reduce<
+    BasicUser[]
+  >(
+    (acc, { email, isMentionable }) =>
+      isMentionable && !emailsOfUsersWithPinboardPermission.includes(email)
+        ? [
+            ...acc,
+            {
+              email,
+              isMentionable: false,
+            },
+          ]
+        : acc,
+    []
+  );
+  if (basicUsersWherePinboardPermissionRemoved.length > 0) {
+    console.log(
+      "DETECTED PINBOARD PERMISSIONS REMOVED FOR ",
+      basicUsersWherePinboardPermissionRemoved.map(({ email }) => email)
     );
+  }
 
-    if (newUserEmails && newUserEmails.length > 0) {
-      console.log("PINBOARD PERMISSIONS ADDED FOR ", newUserEmails);
-    } else {
-      console.log("NO CHANGE TO PINBOARD PERMISSIONS, exiting early");
-      return;
-    }
+  const emailsToLookup = emailsOfUsersWithPinboardPermission.filter(
+    (email) => isNightlyFullRun || !storedUsersEmails.includes(email)
+  );
+
+  if (isNightlyFullRun) {
+    console.log("NIGHTLY FULL RUN");
+  } else if (emailsToLookup.length > 0) {
+    console.log("DETECTED PINBOARD PERMISSIONS ADDED FOR ", emailsToLookup);
+  } else if (basicUsersWherePinboardPermissionRemoved.length === 0) {
+    console.log("NO CHANGE TO PINBOARD PERMISSIONS, exiting early");
+    return;
   }
 
   const pandaConfig = await getPandaConfig<{
@@ -115,92 +139,57 @@ export const handler = async () => {
     auth,
   });
 
-  const getAllUsers = async (
-    nextPageToken?: string
-  ): Promise<admin_directory_v1.Schema$User[]> => {
-    const googleResponse = (
-      await directoryService.users.list({
-        customer: "my_customer",
-        pageToken: nextPageToken,
-        viewType: "domain_public",
-        maxResults: 500,
-      })
-    ).data;
+  const basicUsersWithPinboardPermission: BasicUser[] = await Promise.all(
+    emailsToLookup.map(async (emailFromPermission) => {
+      const userResult = await directoryService.users
+        .get({
+          userKey: emailFromPermission,
+        })
+        .catch((_) => _.response);
 
-    if (!googleResponse.users) {
-      console.error(googleResponse);
-      throw Error(
-        "Empty list of users in call to 'directoryService.users.list()'"
-      );
-    }
-
-    return googleResponse.nextPageToken
-      ? [
-          ...googleResponse.users,
-          ...(await getAllUsers(googleResponse.nextPageToken)),
-        ]
-      : googleResponse.users;
-  };
-
-  interface BasicUser {
-    resourceName: string;
-    email: string;
-    firstName: string;
-    lastName: string;
-    [userTableTTLAttribute]: number;
-  }
-
-  // users will be removed from the table after 3 days of not being updated
-  // (because they have either had their 'pinboard' permission has been removed or they've left the organisation)
-  const ttlEpochSeconds = Date.now() / 1000 + THREE_DAYS_IN_SECONDS;
-
-  const basicUsersWithPinboardPermission = (await getAllUsers()).reduce(
-    (acc, { id, ...user }) => {
+      if (userResult.status === 404) {
+        return {
+          email: emailFromPermission,
+          isMentionable: false,
+        };
+      }
+      if (!userResult.data) {
+        throw Error("Invalid response from Google Directory API");
+      }
+      const { id, ...user } = userResult.data;
       const email = user.primaryEmail?.endsWith(GUARDIAN_EMAIL_DOMAIN)
         ? user.primaryEmail
         : user.emails.find((_: { address: string }) =>
             _.address.endsWith(GUARDIAN_EMAIL_DOMAIN)
-          );
-
-      if (!emailsOfUsersWithPinboardPermission.includes(email)) {
-        console.log(
-          `Skipping ${email} as they do not have 'pinboard' permission.`
-        );
-        return acc;
-      } else if (id && email && user.name?.givenName && user.name?.familyName) {
-        return [
-          ...acc,
-          {
-            resourceName: `people/${id}`,
-            email,
-            firstName: user.name.givenName,
-            lastName: user.name.familyName,
-            [userTableTTLAttribute]: ttlEpochSeconds,
-          },
-        ];
-      } else {
-        console.error(`Key information missing for user ${email}`, user);
-        return acc;
-      }
-    },
-    [] as BasicUser[]
+          )?.address;
+      return {
+        resourceName: `people/${userResult.data.id}`,
+        email,
+        firstName: user.name?.givenName || undefined,
+        lastName: user.name?.familyName || undefined,
+        isMentionable: true,
+      };
+    })
   );
 
   interface PhotoUrlLookup {
     [resourceName: string]: string;
   }
   const buildPhotoUrlLookup = async (
-    users: BasicUser[]
+    resourceNames: string[]
   ): Promise<PhotoUrlLookup> => {
-    const hasMoreThan50Remaining = users.length > 50;
+    if (resourceNames.length === 0) {
+      return {};
+    }
+    const hasMoreThan50Remaining = resourceNames.length > 50;
     const usersToRequestInThisBatch = hasMoreThan50Remaining
-      ? users.slice(0, 50)
-      : users;
+      ? resourceNames.slice(0, 50)
+      : resourceNames;
 
     const thisBatchLookup = (
       await peopleService.people.getBatchGet({
         personFields: "photos",
-        resourceNames: usersToRequestInThisBatch.map((_) => _.resourceName),
+        resourceNames: usersToRequestInThisBatch,
       })
     ).data.responses?.reduce((acc, { person, requestedResourceName }) => {
       const maybePhotoUrl = person?.photos?.find(({ url }) => url)?.url;
@@ -219,37 +208,54 @@ export const handler = async () => {
     return hasMoreThan50Remaining
       ? {
           ...thisBatchLookup,
-          ...(await buildPhotoUrlLookup(users.slice(50, users.length))),
+          ...(await buildPhotoUrlLookup(
+            resourceNames.slice(50, resourceNames.length)
+          )),
         }
       : thisBatchLookup;
   };
   const photoUrlLookup = await buildPhotoUrlLookup(
-    basicUsersWithPinboardPermission
+    basicUsersWithPinboardPermission.reduce<string[]>(
+      (acc, { resourceName }) => (resourceName ? [...acc, resourceName] : acc),
+      []
+    )
   );
 
+  const usersToUpsert: BasicUser[] = [
+    ...basicUsersWithPinboardPermission,
+    ...basicUsersWherePinboardPermissionRemoved,
+  ];
+
   return await Promise.allSettled(
-    basicUsersWithPinboardPermission.map(
-      ({ resourceName, email, firstName, lastName }) => {
-        const maybeAvatarUrl = photoUrlLookup[resourceName];
+    usersToUpsert.map(
+      ({ resourceName, email, firstName, lastName, isMentionable }) => {
+        const maybeAvatarUrl = resourceName && photoUrlLookup[resourceName];
 
         console.log(`Upserting details for user ${email}`);
-        return dynamo
+
+        const upsertResult = dynamo
           .update({
             TableName: usersTableName,
             Key: {
               email,
             },
-            UpdateExpression: `set firstName = :firstName, lastName = :lastName${
+            UpdateExpression: `set isMentionable = :isMentionable${
+              firstName ? ", firstName = :firstName" : ""
+            }${lastName ? ", lastName = :lastName" : ""}${
               maybeAvatarUrl ? ", avatarUrl = :avatarUrl" : ""
-            }, ${userTableTTLAttribute} = :${userTableTTLAttribute}`,
+            }`,
             ExpressionAttributeValues: {
               ":firstName": firstName,
               ":lastName": lastName,
               ":avatarUrl": maybeAvatarUrl,
-              [`:${userTableTTLAttribute}`]: ttlEpochSeconds,
+              ":isMentionable": isMentionable,
             },
           })
           .promise();
+
+        upsertResult.catch(console.error);
+
+        return upsertResult;
       }
     )
   );


### PR DESCRIPTION
https://trello.com/c/RIfC9Vqc/550-run-pinboard-user-refresher-lambda-on-permission-change

Previously the `users-refresher-lambda` ran on a 6 hourly schedule (to keep load on google APIs low), which kept our list of users (needed for name resolution, avatars and to populate the mentions suggestions) somewhat up to date. However the recent live blog pilots highlighted the fact that we still needed to run this lambda manually after a permission change to avoid waiting up to 6 hours before users could safely use pinboard.

Initially we hoped to trigger the `users-refresher-lambda` whenever permissions actually change (see https://github.com/guardian/editorial-tools-pinboard/pull/118) however without adding lots of complex infrastructure (including making changes to [guardian/permissions](https://github.com/guardian/permissions)) this is not possible.

## What does this change?
Instead, here we increase the frequency of the `users-refresher-lambda` schedule to **every minute** and with a payload of `{isProcessPermissionChangesOnly: true}` which checks there are actually pinboard permission changes and looks-up only those against the Google APIs. Note that users who have the permission removed are marked as `isMentionable: false`

We also introduce another schedule, which daily does a full run to ensure users who've left are marked as `isMentionable: false`.

Mention suggestions are now only populated with users with `isMentionable: true`. This new approach replaces the previous TTL concept (see #46 and #50) and retains user rows indefinitely, preferring a flag which is more explicit (and also makes the impending move away from Dynamo to a relational DB easier). 

## How to test
With this deployed to CODE

- change some non-pinboard permissions in CODE and see `NO CHANGE TO PINBOARD PERMISSIONS, exiting early` in the logs
- add the pinboard permission for someone, and see `DETECTED PINBOARD PERMISSIONS ADDED FOR ` in the logs (followed by the usual log lines about upserting).
- remove the pinboard permission for someone, and see `DETECTED PINBOARD PERMISSIONS REMOVED FOR ` in the logs (followed by the usual log lines about upserting).
- if left overnight (or run manually), see `FULL RUN` in the logs (followed by the usual log lines about upserting).

## How can we measure success?
No dev intervention required when CP add new users to pinboard, and they can start using pinboard safely within a minute.

## Have we considered potential risks?
This will cost a touch more, but since pinboard currently costs only a few cents per month - this is OK.
