### PR TITLE
move display of `NotTrackedInWorkflow` into `SelectPinboard`

### DIFF
--- a/client/src/globalState.tsx
+++ b/client/src/globalState.tsx
@@ -202,21 +202,6 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
     pinboardData: PinboardData,
     isOpenInNewTab: boolean
   ) => {
-    if (isOpenInNewTab) {
-      const hostname = window.location.hostname;
-      const composerDomain =
-        hostname.includes(".local.") ||
-        hostname.includes(".code.") ||
-        hostname.includes(".test.")
-          ? "code.dev-gutools.co.uk"
-          : "gutools.co.uk";
-      const composerUrl = `https://composer.${composerDomain}/content/${
-        pinboardData.composerId || ".."
-      }?${EXPAND_PINBOARD_QUERY_PARAM}=true`;
-
-      window?.open(composerUrl, "_blank")?.focus();
-    }
-
     if (!activePinboardIds.includes(pinboardData.id)) {
       addManuallyOpenedPinboardId(pinboardData.id).then(
         (result) =>
@@ -230,10 +215,20 @@ export const GlobalStateProvider: React.FC<GlobalStateProviderProps> = ({
       );
     }
 
-    if (
-      !isPinboardData(preselectedPinboard) ||
-      preselectedPinboard.id === pinboardData.id
-    ) {
+    if (isOpenInNewTab) {
+      const hostname = window.location.hostname;
+      const composerDomain =
+        hostname.includes(".local.") ||
+        hostname.includes(".code.") ||
+        hostname.includes(".test.")
+          ? "code.dev-gutools.co.uk"
+          : "gutools.co.uk";
+      const composerUrl = `https://composer.${composerDomain}/content/${
+        pinboardData.composerId || ".."
+      }?${EXPAND_PINBOARD_QUERY_PARAM}=true`;
+
+      window?.open(composerUrl, "_blank")?.focus();
+    } else {
       setSelectedPinboardId(pinboardData.id);
     }
   };

--- a/client/src/notTrackedInWorkflow.tsx
+++ b/client/src/notTrackedInWorkflow.tsx
@@ -3,7 +3,7 @@ import { standardPanelContainerCss } from "./styling";
 
 export const NotTrackedInWorkflow = () => (
   <div css={standardPanelContainerCss}>
-    In order to use Pinboard, please:
+    In order to use Pinboard with this piece, please:
     <ol>
       <li>Track this piece in Workflow using the left side panel</li>
       <li>Refresh the page</li>

--- a/client/src/panel.tsx
+++ b/client/src/panel.tsx
@@ -7,7 +7,6 @@ import {
   panelCornerSize,
   right,
 } from "./styling";
-import { NotTrackedInWorkflow } from "./notTrackedInWorkflow";
 import { Pinboard } from "./pinboard";
 import { SelectPinboard } from "./selectPinboard";
 import { neutral, space } from "@guardian/source-foundations";
@@ -22,7 +21,6 @@ export const Panel: React.FC = () => {
     activePinboards,
     activePinboardIds,
     selectedPinboardId,
-    preselectedPinboard,
     clearSelectedPinboard,
     activeTab,
     setActiveTab,
@@ -38,9 +36,6 @@ export const Panel: React.FC = () => {
     }
     if (selectedPinboardId) {
       return selectedPinboard?.title || "Loading pinboard...";
-    }
-    if (preselectedPinboard === "notTrackedInWorkflow") {
-      return "No pinboard";
     }
     return "Select a pinboard";
   })();
@@ -103,11 +98,7 @@ export const Panel: React.FC = () => {
         </span>
       </Navigation>
 
-      {preselectedPinboard === "notTrackedInWorkflow" ? (
-        <NotTrackedInWorkflow />
-      ) : (
-        !selectedPinboardId && <SelectPinboard />
-      )}
+      {!selectedPinboardId && <SelectPinboard />}
 
       {
         // The active pinboards are always mounted, so that we receive new item notifications

--- a/client/src/selectPinboard.tsx
+++ b/client/src/selectPinboard.tsx
@@ -20,6 +20,7 @@ import {
   TextInput,
 } from "@guardian/source-react-components";
 import { SvgMagnifyingGlass } from "../icons/SvgMagnifyingGlass";
+import { NotTrackedInWorkflow } from "./notTrackedInWorkflow";
 
 const textMarginCss: CSSObject = {
   margin: `${space["1"]}px ${space["2"]}px`,
@@ -119,8 +120,9 @@ export const SelectPinboard: React.FC = () => {
       pinboardData.id === preselectedPinboard.id;
 
     const isOpenInNewTab =
-      isPinboardData(preselectedPinboard) &&
-      pinboardData.id !== preselectedPinboard.id;
+      preselectedPinboard === "notTrackedInWorkflow" ||
+      (isPinboardData(preselectedPinboard) &&
+        pinboardData.id !== preselectedPinboard.id);
 
     return (
       <div
@@ -273,6 +275,9 @@ export const SelectPinboard: React.FC = () => {
           },
         }}
       >
+        {preselectedPinboard === "notTrackedInWorkflow" && (
+          <NotTrackedInWorkflow />
+        )}
         {payloadToBeSent && (
           <div
             css={css`


### PR DESCRIPTION
...rather than it being its own page, that one couldn't navigate up from (e.g. when you receive a notification on another pinboard).

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/19289579/161076242-18e14dbf-d0f5-4ced-b94a-2266177b624f.png) | ![image](https://user-images.githubusercontent.com/19289579/161076145-79fd324e-2d2e-4a4b-87bb-ae22d81bb6ab.png) |